### PR TITLE
Fixup naming inconsistencies between tchannel4j and the Protocol.

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/CancelCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/CancelCodec.java
@@ -39,7 +39,7 @@ public class CancelCodec extends MessageToMessageCodec<TFrame, Cancel> {
         ByteBuf buffer = ctx.alloc().heapBuffer();
         buffer.writeInt((int) msg.getTtl());
         CodecUtils.encodeTrace(msg.getTracing(), buffer);
-        CodecUtils.encodeString(msg.getMessage(), buffer);
+        CodecUtils.encodeString(msg.getWhy(), buffer);
         TFrame frame = new TFrame(buffer.writerIndex(), MessageType.Cancel, msg.getId(), buffer);
         out.add(frame);
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
@@ -48,8 +48,7 @@ public class InitRequestHandler extends ChannelHandlerAdapter {
                     ctx.writeAndFlush(new InitResponse(
                             initRequestMessage.getId(),
                             AbstractInitMessage.DEFAULT_VERSION,
-                            initRequestMessage.getHostPort(),
-                            initRequestMessage.getProcessName()
+                            initRequestMessage.getHeaders()
                     ));
                     ctx.pipeline().remove(this);
                 } else {

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractCallMessage.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractCallMessage.java
@@ -28,16 +28,17 @@ public abstract class AbstractCallMessage extends AbstractMessage {
     public static final int MAX_ARG1_LENGTH = 16384;
     public static final byte MORE_FRAGMENTS_TO_FOLLOW_MASK = (byte) 0x01;
 
-    private final byte flags;
-    private final byte checksumType;
+    protected final byte flags;
+    protected final byte checksumType;
     // TODO: `checksums` are optional, can be removed for possible perf. wins.. //
-    private final int checksum;
-    private ByteBuf arg1;
-    private ByteBuf arg2;
-    private ByteBuf arg3;
+    protected final int checksum;
+    protected ByteBuf arg1;
+    protected ByteBuf arg2;
+    protected ByteBuf arg3;
 
     public AbstractCallMessage(long id, MessageType messageType, byte flags, byte checksumType, int checksum,
                                ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
+
         super(id, messageType);
         this.flags = flags;
         this.checksumType = checksumType;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractInitMessage.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractInitMessage.java
@@ -21,20 +21,21 @@
  */
 package com.uber.tchannel.messages;
 
+import java.util.Map;
+
 public abstract class AbstractInitMessage extends AbstractMessage {
     public static final int DEFAULT_VERSION = 2;
+    public static final String DEFAULT_HOST_PORT = "0.0.0.0:0";
     public static final String HOST_PORT_KEY = "host_port";
     public static final String PROCESS_NAME_KEY = "process_name";
 
-    private final int version;
-    private final String hostPort;
-    private final String processName;
+    protected final int version;
+    protected final Map<String, String> headers;
 
-    public AbstractInitMessage(long id, MessageType messageType, int version, String hostPort, String processName) {
+    public AbstractInitMessage(long id, MessageType messageType, int version, Map<String, String> headers) {
         super(id, messageType);
         this.version = version;
-        this.hostPort = hostPort;
-        this.processName = processName;
+        this.headers = headers;
     }
 
     @Override
@@ -42,22 +43,58 @@ public abstract class AbstractInitMessage extends AbstractMessage {
         return String.format(
                 "<%s id=%d version=%d hostPort=%s processName=%s>",
                 this.getClass().getCanonicalName(),
-                this.getId(),
+                this.id,
                 this.version,
-                this.hostPort,
-                this.processName
+                this.getHostPort(),
+                this.getProcessName()
         );
     }
 
+    /**
+     * version is a 16 bit number. The currently specified protocol version is 2.
+     * If new versions are required, this is where a common version can be negotiated.
+     *
+     * @return 16-bit unsigned integer representing the specified protocol version.
+     */
     public int getVersion() {
         return version;
     }
 
-    public String getHostPort() {
-        return hostPort;
+    /**
+     * There are a variable number of key/value pairs. For version 2, the following are required:
+     * <p>
+     * host_port: where this process can be reached. format: address:port
+     * process_name: additional identifier for this instance, used for logging. format: arbitrary string
+     *
+     * @return Map of headers
+     */
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 
+    /**
+     * Where the sending process can be reached.
+     * <p>
+     * Key: host_port
+     * Format: address:port
+     * Protocol Description: where this process can be reached
+     *
+     * @return the `host_port` key for the `headers` member.
+     */
+    public String getHostPort() {
+        return this.headers.get(HOST_PORT_KEY);
+    }
+
+    /**
+     * An additional process identifier for the sending process, used for logging.
+     * <p>
+     * Key: process_name
+     * Format: arbitrary string
+     * Protocol Description: additional identifier for this instance, used for logging
+     *
+     * @return the `process_name` key for the `headers` member.
+     */
     public String getProcessName() {
-        return processName;
+        return this.headers.get(PROCESS_NAME_KEY);
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractMessage.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/AbstractMessage.java
@@ -22,8 +22,8 @@
 package com.uber.tchannel.messages;
 
 public abstract class AbstractMessage implements Message {
-    private final long id;
-    private final MessageType messageType;
+    protected final long id;
+    protected final MessageType messageType;
 
     public AbstractMessage(long id, MessageType messageType) {
         this.id = id;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequest.java
@@ -26,6 +26,20 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.Map;
 
+/**
+ * This is the primary RPC mechanism. The triple of (arg1, arg2, arg3) is sent to "service" via the remote end
+ * of this connection.
+ * <p>
+ * Whether connecting directly to a service or through a service router, the service name is always specified.
+ * This supports an explicit router model as well as peers electing to delegate some requests to another service.
+ * <p>
+ * A forwarding intermediary can relay payloads without understanding the contents of the args triple.
+ * <p>
+ * A {@link CallRequest} may be fragmented across multiple frames. If so, the first frame is a {@link CallRequest},
+ * and all subsequent frames are {@link CallRequestContinue} frames.
+ * <p>
+ * The size of arg1 is at most 16KiB.
+ */
 public class CallRequest extends AbstractCallMessage {
 
     private final long ttl;
@@ -33,9 +47,9 @@ public class CallRequest extends AbstractCallMessage {
     private final String service;
     private final Map<String, String> headers;
 
-    public CallRequest(long id, byte flags, long ttl, Trace tracing, String service,
-                       Map<String, String> headers, byte checksumType, int checksum,
-                       ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
+    public CallRequest(long id, byte flags, long ttl, Trace tracing, String service, Map<String, String> headers,
+                       byte checksumType, int checksum, ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
+
         super(id, MessageType.CallRequest, flags, checksumType, checksum, arg1, arg2, arg3);
         this.ttl = ttl;
         this.service = service;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequestContinue.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequestContinue.java
@@ -26,6 +26,7 @@ import io.netty.buffer.ByteBuf;
 public class CallRequestContinue extends AbstractCallMessage {
     public CallRequestContinue(long id, byte flags, byte checksumType, int checksum, ByteBuf arg1, ByteBuf arg2,
                                ByteBuf arg3) {
+
         super(id, MessageType.CallRequestContinue, flags, checksumType, checksum, arg1, arg2, arg3);
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Cancel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Cancel.java
@@ -27,13 +27,13 @@ public class Cancel extends AbstractMessage {
 
     private final long ttl;
     private final Trace tracing;
-    private final String message;
+    private final String why;
 
-    public Cancel(long id, long ttl, Trace tracing, String message) {
+    public Cancel(long id, long ttl, Trace tracing, String why) {
         super(id, MessageType.Cancel);
         this.ttl = ttl;
         this.tracing = tracing;
-        this.message = message;
+        this.why = why;
     }
 
     public long getTtl() {
@@ -44,7 +44,7 @@ public class Cancel extends AbstractMessage {
         return tracing;
     }
 
-    public String getMessage() {
-        return message;
+    public String getWhy() {
+        return why;
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/InitRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/InitRequest.java
@@ -21,10 +21,17 @@
  */
 package com.uber.tchannel.messages;
 
+import java.util.Map;
+
+/**
+ * This must be the first message sent on a new connection. It is used to negotiate a common protocol version
+ * and describe the service names on both ends. In the future, we will likely use this to negotiate authentication
+ * and authorization between services.
+ */
 public class InitRequest extends AbstractInitMessage {
 
-    public InitRequest(long id, int version, String hostPort, String processName) {
-        super(id, MessageType.InitRequest, version, hostPort, processName);
+    public InitRequest(long id, int version, Map<String, String> headers) {
+        super(id, MessageType.InitRequest, version, headers);
     }
 
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/InitResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/InitResponse.java
@@ -21,10 +21,17 @@
  */
 package com.uber.tchannel.messages;
 
+import java.util.Map;
+
+/**
+ * Similar to {@link InitRequest}. The initiator requests a version number, and the server responds with the
+ * actual version that will be used for the rest of this connection. The header name/values are the same,
+ * but identify the server.
+ */
 public class InitResponse extends AbstractInitMessage {
 
-    public InitResponse(long id, int version, String hostPort, String processName) {
-        super(id, MessageType.InitResponse, version, hostPort, processName);
+    public InitResponse(long id, int version, Map<String, String> headers) {
+        super(id, MessageType.InitResponse, version, headers);
     }
 
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
@@ -50,7 +50,7 @@ public class CancelCodecTest {
         assertEquals(cancel.getTtl(), newCancel.getTtl());
         assertTrue(newCancel.getTtl() > 0);
         assertEquals(cancel.getTracing().traceId, newCancel.getTracing().traceId);
-        assertEquals(cancel.getMessage(), newCancel.getMessage());
+        assertEquals(cancel.getWhy(), newCancel.getWhy());
 
     }
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/InitMessageCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/InitMessageCodecTest.java
@@ -23,11 +23,14 @@ package com.uber.tchannel.codecs;
  */
 
 import com.uber.tchannel.framing.TFrame;
+import com.uber.tchannel.messages.AbstractInitMessage;
 import com.uber.tchannel.messages.InitRequest;
 import com.uber.tchannel.messages.InitResponse;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,7 +45,14 @@ public class InitMessageCodecTest {
                 new InitMessageCodec()
         );
 
-        InitRequest initReq = new InitRequest(42, InitRequest.DEFAULT_VERSION, "0.0.0.0:0", "test-process");
+        InitRequest initReq = new InitRequest(
+                42,
+                InitRequest.DEFAULT_VERSION,
+                new HashMap<String, String>() {{
+                    put(AbstractInitMessage.HOST_PORT_KEY, "0.0.0.0:0");
+                    put(AbstractInitMessage.PROCESS_NAME_KEY, "test-process");
+                }}
+        );
 
         channel.writeOutbound(initReq);
         channel.writeInbound(channel.readOutbound());
@@ -65,7 +75,14 @@ public class InitMessageCodecTest {
                 new InitMessageCodec()
         );
 
-        InitResponse initResponse = new InitResponse(42, InitRequest.DEFAULT_VERSION, "0.0.0.0:0", "test-process");
+        InitResponse initResponse = new InitResponse(
+                42,
+                InitRequest.DEFAULT_VERSION,
+                new HashMap<String, String>() {{
+                    put(AbstractInitMessage.HOST_PORT_KEY, "0.0.0.0:0");
+                    put(AbstractInitMessage.PROCESS_NAME_KEY, "test-process");
+                }}
+        );
 
         channel.writeOutbound(initResponse);
         channel.writeInbound(channel.readOutbound());

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestHandlerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestHandlerTest.java
@@ -22,13 +22,18 @@
 package com.uber.tchannel.handlers;
 
 import com.uber.tchannel.Fixtures;
-import com.uber.tchannel.messages.*;
+import com.uber.tchannel.messages.AbstractInitMessage;
+import com.uber.tchannel.messages.CallRequest;
+import com.uber.tchannel.messages.ErrorMessage;
+import com.uber.tchannel.messages.InitRequest;
+import com.uber.tchannel.messages.InitResponse;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -48,7 +53,15 @@ public class InitRequestHandlerTest {
 
         assertEquals(channel.pipeline().names().size(), 3);
 
-        InitRequest initRequest = new InitRequest(42, AbstractInitMessage.DEFAULT_VERSION, "0.0.0.0:0", "test-process");
+        InitRequest initRequest = new InitRequest(
+                42,
+                AbstractInitMessage.DEFAULT_VERSION,
+                new HashMap<String, String>() {{
+                    put(AbstractInitMessage.HOST_PORT_KEY, "0.0.0.0:0");
+                    put(AbstractInitMessage.PROCESS_NAME_KEY, "test-process");
+                }}
+        );
+
         channel.writeInbound(initRequest);
         channel.writeOutbound(channel.readInbound());
 
@@ -83,7 +96,14 @@ public class InitRequestHandlerTest {
         );
 
 
-        InitRequest initRequest = new InitRequest(42, AbstractInitMessage.DEFAULT_VERSION, "0.0.0.0:0", "test-process");
+        InitRequest initRequest = new InitRequest(42,
+                AbstractInitMessage.DEFAULT_VERSION,
+                new HashMap<String, String>() {{
+                    put(AbstractInitMessage.HOST_PORT_KEY, "0.0.0.0:0");
+                    put(AbstractInitMessage.PROCESS_NAME_KEY, "test-process");
+                }}
+        );
+
         channel.writeInbound(initRequest);
         channel.writeOutbound(channel.readInbound());
 

--- a/tchannel-example/src/main/java/com/uber/tchannel/ping/PingClientHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/ping/PingClientHandler.java
@@ -21,6 +21,7 @@
  */
 package com.uber.tchannel.ping;
 
+import com.uber.tchannel.messages.AbstractInitMessage;
 import com.uber.tchannel.messages.AbstractMessage;
 import com.uber.tchannel.messages.ErrorMessage;
 import com.uber.tchannel.messages.InitRequest;
@@ -32,11 +33,21 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 
+import java.util.HashMap;
+
 public class PingClientHandler extends ChannelHandlerAdapter {
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        InitRequest initRequest = new InitRequest(42, InitRequest.DEFAULT_VERSION, "0.0.0.0:0", "test-process");
+        InitRequest initRequest = new InitRequest(42,
+                AbstractInitMessage.DEFAULT_VERSION,
+                new HashMap<String, String>() {
+                    {
+                        put(AbstractInitMessage.HOST_PORT_KEY, "0.0.0.0:0");
+                        put(AbstractInitMessage.PROCESS_NAME_KEY, "test-process");
+                    }
+                }
+        );
         ChannelFuture f = ctx.writeAndFlush(initRequest);
         f.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }


### PR DESCRIPTION
We had mistakenly renamed `Cancel.why` -> `Cancel.message`. This renames it
back. We had also made `host_port` and `process_name` fields in
InitRequest, instead of making them proper headers, causing all sorts of
mapping back and forth. Now, InitRequest has a proper
`Map<String, String>` representing headers, with helper accessors for the
required headers, namly `host_port` and `process_name`.

This diff also includes some header docs for messages that are
particularly confusing. The literature comes as closely from the
protocol def as possible, with some grammar / usage changes to match the
tone of the comment.
