### PR TITLE
Expose TTL and Response Code

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
@@ -24,6 +24,7 @@ package com.uber.tchannel.api;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public final class Request<T> {
 
@@ -82,10 +83,13 @@ public final class Request<T> {
 
     public static class Builder<U> {
 
-        private static final long DEFAULT_TTL = 100;
-
         private String service;
-        private long ttl = DEFAULT_TTL;
+        /*
+        * Time To Live in milliseconds. Defaults to a reasonable 100ms, as requests *cannot* be made without a TTL set.
+        *
+        * see: https://github.com/uber/tchannel/blob/master/docs/protocol.md#ttl4
+        */
+        private long ttl = 100;
         private Map<String, String> transportHeaders = new HashMap<>();
         private String endpoint;
         private Map<String, String> headers = new HashMap<>();
@@ -97,8 +101,22 @@ public final class Request<T> {
             this.endpoint = endpoint;
         }
 
+        /**
+         * @param ttl TTL in milliseconds
+         * @return Builder
+         */
         public Builder<U> setTTL(long ttl) {
             this.ttl = ttl;
+            return this;
+        }
+
+        /**
+         * @param ttl      TTL in `timeUnit` units
+         * @param timeUnit time unit for the `ttl`
+         * @return Builder
+         */
+        public Builder<U> setTTL(long ttl, TimeUnit timeUnit) {
+            this.ttl = TimeUnit.MILLISECONDS.convert(ttl, timeUnit);
             return this;
         }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
@@ -28,6 +28,7 @@ import java.util.Map;
 public final class Request<T> {
 
     private final String service;
+    private final long ttl;
     private final Map<String, String> transportHeaders;
     private final String endpoint;
     private final Map<String, String> headers;
@@ -35,6 +36,7 @@ public final class Request<T> {
 
     private Request(Builder<T> builder) {
         this.service = builder.service;
+        this.ttl = builder.ttl;
         this.transportHeaders = builder.transportHeaders;
         this.endpoint = builder.endpoint;
         this.headers = builder.headers;
@@ -43,6 +45,10 @@ public final class Request<T> {
 
     public String getService() {
         return service;
+    }
+
+    public long getTTL() {
+        return ttl;
     }
 
     public Map<String, String> getTransportHeaders() {
@@ -76,7 +82,10 @@ public final class Request<T> {
 
     public static class Builder<U> {
 
+        private static final long DEFAULT_TTL = 100;
+
         private String service;
+        private long ttl = DEFAULT_TTL;
         private Map<String, String> transportHeaders = new HashMap<>();
         private String endpoint;
         private Map<String, String> headers = new HashMap<>();
@@ -86,6 +95,11 @@ public final class Request<T> {
             this.body = body;
             this.service = service;
             this.endpoint = endpoint;
+        }
+
+        public Builder<U> setTTL(long ttl) {
+            this.ttl = ttl;
+            return this;
         }
 
         public Builder<U> setTransportHeader(String key, String value) {
@@ -115,6 +129,10 @@ public final class Request<T> {
 
             if (endpoint == null) {
                 throw new IllegalStateException("`endpoint` cannot be null.");
+            }
+
+            if (ttl <= 0) {
+                throw new IllegalStateException("`ttl` must be greater than 0.");
             }
 
             return this;

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/Request.java
@@ -82,13 +82,10 @@ public final class Request<T> {
         private Map<String, String> headers = new HashMap<>();
         private U body;
 
-        public Builder(U body) {
+        public Builder(U body, String service, String endpoint) {
             this.body = body;
-        }
-
-        public Builder<U> setService(String service) {
             this.service = service;
-            return this;
+            this.endpoint = endpoint;
         }
 
         public Builder<U> setTransportHeader(String key, String value) {
@@ -98,11 +95,6 @@ public final class Request<T> {
 
         public Builder<U> setTransportHeaders(Map<String, String> transportHeaders) {
             this.transportHeaders.putAll(transportHeaders);
-            return this;
-        }
-
-        public Builder<U> setEndpoint(String endpoint) {
-            this.endpoint = endpoint;
             return this;
         }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/Response.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/Response.java
@@ -31,12 +31,14 @@ public final class Response<T> {
     private final String endpoint;
     private final Map<String, String> headers;
     private final T body;
+    private final ResponseCode responseCode;
 
     private Response(Builder<T> builder) {
         this.transportHeaders = builder.transportHeaders;
         this.endpoint = builder.endpoint;
         this.headers = builder.headers;
         this.body = builder.body;
+        this.responseCode = builder.responseCode;
     }
 
     public String getEndpoint() {
@@ -51,11 +53,20 @@ public final class Response<T> {
         return body;
     }
 
+    public Map<String, String> getTransportHeaders() {
+        return transportHeaders;
+    }
+
+    public ResponseCode getResponseCode() {
+        return responseCode;
+    }
+
     @Override
     public String toString() {
         return String.format(
-                "<%s transportHeaders=%s endpoint=%s headers=%s body=%s>",
+                "<%s responseCode=%s transportHeaders=%s endpoint=%s headers=%s body=%s>",
                 this.getClass().getSimpleName(),
+                this.responseCode,
                 this.transportHeaders,
                 this.endpoint,
                 this.headers,
@@ -69,9 +80,12 @@ public final class Response<T> {
         private String endpoint;
         private Map<String, String> headers = new HashMap<>();
         private U body;
+        private ResponseCode responseCode;
 
-        public Builder(U body) {
+        public Builder(U body, String endpoint, ResponseCode responseCode) {
             this.body = body;
+            this.endpoint = endpoint;
+            this.responseCode = responseCode;
         }
 
         public Builder<U> setTransportHeader(String key, String value) {
@@ -81,11 +95,6 @@ public final class Response<T> {
 
         public Builder<U> setTransportHeaders(Map<String, String> transportHeaders) {
             this.transportHeaders.putAll(transportHeaders);
-            return this;
-        }
-
-        public Builder<U> setEndpoint(String endpoint) {
-            this.endpoint = endpoint;
             return this;
         }
 
@@ -103,6 +112,9 @@ public final class Response<T> {
 
             if (endpoint == null) {
                 throw new IllegalStateException("`endpoint` cannot be null.");
+            }
+            if (responseCode == null) {
+                throw new IllegalStateException("`responseCode` cannot be null.");
             }
 
             return this;

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/ResponseCode.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/ResponseCode.java
@@ -20,32 +20,30 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.ping;
+package com.uber.tchannel.api;
 
-import com.uber.tchannel.api.Request;
-import com.uber.tchannel.api.RequestHandler;
-import com.uber.tchannel.api.Response;
-import com.uber.tchannel.api.ResponseCode;
+public enum ResponseCode {
+    OK((byte) 0x00),
+    Error((byte) 0x01);
 
-public class PingRequestHandler implements RequestHandler<Ping, Pong> {
+    private final byte code;
 
-    @Override
-    public Class<Ping> getRequestType() {
-        return Ping.class;
+    ResponseCode(byte code) {
+        this.code = code;
     }
 
-    @Override
-    public Class<Pong> getResponseType() {
-        return Pong.class;
+    public static ResponseCode fromByte(byte code) {
+        switch (code) {
+            case 0x00:
+                return OK;
+            case 0x01:
+                return Error;
+            default:
+                return null;
+        }
     }
 
-    @Override
-    public Response<Pong> handle(Request<Ping> request) {
-
-        return new Response.Builder<>(new Pong("pong!"), request.getEndpoint(), ResponseCode.OK)
-                .setHeaders(request.getHeaders())
-                .build();
-
+    public byte byteValue() {
+        return this.code;
     }
-
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallRequestCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallRequestCodec.java
@@ -50,7 +50,7 @@ public final class CallRequestCodec extends MessageToMessageCodec<TFrame, CallRe
         buffer.writeByte(msg.getFlags());
 
         // ttl:4
-        buffer.writeInt((int) msg.getTtl());
+        buffer.writeInt((int) msg.getTTL());
 
         // tracing:25
         CodecUtils.encodeTrace(msg.getTracing(), buffer);

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallResponseCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallResponseCodec.java
@@ -22,12 +22,12 @@
 
 package com.uber.tchannel.codecs;
 
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.framing.TFrame;
 import com.uber.tchannel.messages.CallMessage;
 import com.uber.tchannel.messages.CallResponse;
 import com.uber.tchannel.messages.MessageType;
-import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallResponseCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/CallResponseCodec.java
@@ -27,6 +27,7 @@ import com.uber.tchannel.framing.TFrame;
 import com.uber.tchannel.messages.CallMessage;
 import com.uber.tchannel.messages.CallResponse;
 import com.uber.tchannel.messages.MessageType;
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -51,7 +52,7 @@ public final class CallResponseCodec extends MessageToMessageCodec<TFrame, CallR
         buffer.writeByte(msg.getFlags());
 
         // code:1
-        buffer.writeByte(msg.getCode().byteValue());
+        buffer.writeByte(msg.getResponseCode().byteValue());
 
         // tracing:25
         CodecUtils.encodeTrace(msg.getTracing(), buffer);
@@ -86,7 +87,7 @@ public final class CallResponseCodec extends MessageToMessageCodec<TFrame, CallR
         byte flags = frame.payload.readByte();
 
         // code:1
-        CallResponse.CallResponseCode code = CallResponse.CallResponseCode.fromByte(frame.payload.readByte());
+        ResponseCode code = ResponseCode.fromByte(frame.payload.readByte());
 
         // tracing:25
         Trace trace = CodecUtils.decodeTrace(frame.payload);

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/CancelCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/CancelCodec.java
@@ -37,7 +37,7 @@ public class CancelCodec extends MessageToMessageCodec<TFrame, Cancel> {
         ByteBuf buffer = ctx.alloc().buffer();
 
         // ttl:4
-        buffer.writeInt((int) msg.getTtl());
+        buffer.writeInt((int) msg.getTTL());
 
         // tracing:25
         CodecUtils.encodeTrace(msg.getTracing(), buffer);

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/ClaimCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/ClaimCodec.java
@@ -36,7 +36,7 @@ public final class ClaimCodec extends MessageToMessageCodec<TFrame, Claim> {
         ByteBuf buffer = ctx.alloc().buffer(4 + Trace.TRACING_HEADER_LENGTH);
 
         // ttl: 4
-        buffer.writeInt((int) msg.getTtl());
+        buffer.writeInt((int) msg.getTTL());
 
         // tracing: 25
         CodecUtils.encodeTrace(msg.getTracing(), buffer);

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageDefragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageDefragmenter.java
@@ -90,6 +90,7 @@ public class MessageDefragmenter extends MessageToMessageDecoder<CallMessage> {
 
         this.messageMap.put(msg.getId(), new RawRequest(
                 msg.getId(),
+                msg.getTTL(),
                 msg.getService(),
                 msg.getHeaders(),
                 arg1,
@@ -130,6 +131,7 @@ public class MessageDefragmenter extends MessageToMessageDecoder<CallMessage> {
 
         RawRequest updatedRequest = new RawRequest(
                 partialRequest.getId(),
+                partialRequest.getTTL(),
                 partialRequest.getService(),
                 partialRequest.getTransportHeaders(),
                 partialRequest.getArg1(),

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageDefragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageDefragmenter.java
@@ -110,6 +110,7 @@ public class MessageDefragmenter extends MessageToMessageDecoder<CallMessage> {
 
         this.messageMap.put(msg.getId(), new RawResponse(
                 msg.getId(),
+                msg.getResponseCode(),
                 msg.getHeaders(),
                 arg1,
                 arg2,
@@ -151,6 +152,7 @@ public class MessageDefragmenter extends MessageToMessageDecoder<CallMessage> {
 
         RawResponse updatedResponse = new RawResponse(
                 partialResponse.getId(),
+                partialResponse.getResponseCode(),
                 partialResponse.getTransportHeaders(),
                 partialResponse.getArg1(),
                 Unpooled.wrappedBuffer(partialResponse.getArg2(), arg2),

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -22,12 +22,12 @@
 
 package com.uber.tchannel.handlers;
 
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.fragmentation.FragmentationState;
 import com.uber.tchannel.framing.TFrame;
 import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.CallResponse;
-import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.schemes.RawMessage;
 import com.uber.tchannel.schemes.RawRequest;
 import com.uber.tchannel.schemes.RawResponse;

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -27,6 +27,7 @@ import com.uber.tchannel.fragmentation.FragmentationState;
 import com.uber.tchannel.framing.TFrame;
 import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.CallResponse;
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.schemes.RawMessage;
 import com.uber.tchannel.schemes.RawRequest;
 import com.uber.tchannel.schemes.RawResponse;
@@ -84,7 +85,7 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
             CallResponse callResponse = new CallResponse(
                     rawResponse.getId(),
                     flags,
-                    CallResponse.CallResponseCode.OK,
+                    ResponseCode.OK,
                     new Trace(0, 0, 0, (byte) 0x00),
                     rawResponse.getTransportHeaders(),
                     ChecksumType.NoChecksum,

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
@@ -72,13 +72,13 @@ public class RequestRouter extends SimpleChannelInboundHandler<RawRequest> {
         }
 
         // arg1
-        String method = this.serializer.decodeEndpoint(rawRequest);
+        String endpoint = this.serializer.decodeEndpoint(rawRequest);
 
         // Get handler for this method
-        RequestHandler<?, ?> handler = this.requestHandlers.get(method);
+        RequestHandler<?, ?> handler = this.requestHandlers.get(endpoint);
 
         if (handler == null) {
-            throw new RuntimeException(String.format("No handler for %s", method));
+            throw new RuntimeException(String.format("No handler for %s", endpoint));
         }
 
         // arg2
@@ -88,10 +88,8 @@ public class RequestRouter extends SimpleChannelInboundHandler<RawRequest> {
         Object body = this.serializer.decodeBody(rawRequest, handler.getRequestType());
 
         // transform request into form the handler expects
-        Request<?> request = new Request.Builder<>(body)
-                .setEndpoint(method)
+        Request<?> request = new Request.Builder<>(body, rawRequest.getService(), endpoint)
                 .setHeaders(applicationHeaders)
-                .setService(rawRequest.getService())
                 .setTransportHeaders(rawRequest.getTransportHeaders())
                 .build();
 
@@ -100,6 +98,7 @@ public class RequestRouter extends SimpleChannelInboundHandler<RawRequest> {
 
         RawResponse rawResponse = new RawResponse(
                 rawRequest.getId(),
+                response.getResponseCode(),
                 rawRequest.getTransportHeaders(),
                 this.serializer.encodeEndpoint(response.getEndpoint(), argScheme),
                 this.serializer.encodeHeaders(response.getHeaders(), argScheme),

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
@@ -87,8 +87,10 @@ public class ResponseRouter extends SimpleChannelInboundHandler<RawResponse> {
         ResponsePromise<?> responsePromise = this.messageMap.remove(rawResponse.getId());
 
         Response<?> response = new Response.Builder<>(
-                this.serializer.decodeBody(rawResponse, responsePromise.getPromiseType()))
-                .setEndpoint(this.serializer.decodeEndpoint(rawResponse))
+                this.serializer.decodeBody(rawResponse, responsePromise.getPromiseType()),
+                this.serializer.decodeEndpoint(rawResponse),
+                rawResponse.getResponseCode()
+        )
                 .setHeaders(this.serializer.decodeHeaders(rawResponse))
                 .build();
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
@@ -68,6 +68,7 @@ public class ResponseRouter extends SimpleChannelInboundHandler<RawResponse> {
 
         RawRequest rawRequest = new RawRequest(
                 idGenerator.getAndIncrement(),
+                request.getTTL(),
                 request.getService(),
                 request.getTransportHeaders(),
                 serializer.encodeEndpoint(request.getEndpoint(), argScheme),

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/CallRequest.java
@@ -99,7 +99,7 @@ public final class CallRequest implements Message, CallMessage {
         return MessageType.CallRequest;
     }
 
-    public long getTtl() {
+    public long getTTL() {
         return this.ttl;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/CallResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/CallResponse.java
@@ -21,6 +21,7 @@
  */
 package com.uber.tchannel.messages;
 
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
@@ -29,7 +30,7 @@ import io.netty.buffer.ByteBufHolder;
 import java.util.Map;
 
 /**
- * Very similar to {@link CallRequest}, differing only in: adds a code field, no ttl field and no service field.
+ * Very similar to {@link CallRequest}, differing only in: adds a responseCode field, no ttl field and no service field.
  * <p/>
  * All common fields have identical definition to {@link CallRequest}. It is not necessary for arg1 to have the same
  * value between the {@link CallRequest} and the {@link CallResponse}; by convention, existing implementations leave
@@ -41,18 +42,18 @@ public final class CallResponse implements Message, CallMessage {
 
     private final long id;
     private final byte flags;
-    private final CallResponseCode code;
+    private final ResponseCode responseCode;
     private final Trace tracing;
     private final Map<String, String> headers;
     private final ChecksumType checksumType;
     private final int checksum;
     private final ByteBuf payload;
 
-    public CallResponse(long id, byte flags, CallResponseCode code, Trace tracing, Map<String, String> headers,
+    public CallResponse(long id, byte flags, ResponseCode responseCode, Trace tracing, Map<String, String> headers,
                         ChecksumType checksumType, int checksum, ByteBuf payload) {
         this.id = id;
         this.flags = flags;
-        this.code = code;
+        this.responseCode = responseCode;
         this.tracing = tracing;
         this.headers = headers;
         this.checksumType = checksumType;
@@ -69,7 +70,7 @@ public final class CallResponse implements Message, CallMessage {
     }
 
     public boolean ok() {
-        return (this.code == CallResponseCode.OK);
+        return (this.responseCode == ResponseCode.OK);
     }
 
     public boolean moreFragmentsFollow() {
@@ -104,8 +105,8 @@ public final class CallResponse implements Message, CallMessage {
         return this.payload;
     }
 
-    public CallResponseCode getCode() {
-        return code;
+    public ResponseCode getResponseCode() {
+        return responseCode;
     }
 
     public ByteBuf content() {
@@ -116,7 +117,7 @@ public final class CallResponse implements Message, CallMessage {
         return new CallResponse(
                 this.id,
                 this.flags,
-                this.code,
+                this.responseCode,
                 this.tracing,
                 this.headers,
                 this.checksumType,
@@ -129,7 +130,7 @@ public final class CallResponse implements Message, CallMessage {
         return new CallResponse(
                 this.id,
                 this.flags,
-                this.code,
+                this.responseCode,
                 this.tracing,
                 this.headers,
                 this.checksumType,
@@ -168,32 +169,6 @@ public final class CallResponse implements Message, CallMessage {
 
     public boolean release(int i) {
         return this.payload.release(i);
-    }
-
-    public enum CallResponseCode {
-        OK((byte) 0x00),
-        Error((byte) 0x01);
-
-        private final byte code;
-
-        CallResponseCode(byte code) {
-            this.code = code;
-        }
-
-        public static CallResponseCode fromByte(byte code) {
-            switch (code) {
-                case 0x00:
-                    return OK;
-                case 0x01:
-                    return Error;
-                default:
-                    return null;
-            }
-        }
-
-        public byte byteValue() {
-            return this.code;
-        }
     }
 
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Cancel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Cancel.java
@@ -45,7 +45,7 @@ public final class Cancel implements Message {
         this.why = why;
     }
 
-    public long getTtl() {
+    public long getTTL() {
         return ttl;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Claim.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Claim.java
@@ -51,7 +51,7 @@ public final class Claim implements Message {
         return MessageType.Claim;
     }
 
-    public long getTtl() {
+    public long getTTL() {
         return ttl;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
@@ -43,15 +43,17 @@ import java.util.Map;
 public final class RawRequest implements RawMessage {
 
     private final long id;
+    private final long ttl;
     private final String service;
     private final Map<String, String> transportHeaders;
     private final ByteBuf arg1;
     private final ByteBuf arg2;
     private final ByteBuf arg3;
 
-    public RawRequest(long id, String service, Map<String, String> transportHeaders,
+    public RawRequest(long id, long ttl, String service, Map<String, String> transportHeaders,
                       ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
         this.id = id;
+        this.ttl = ttl;
         this.service = service;
         this.transportHeaders = transportHeaders;
         this.arg1 = arg1;
@@ -62,6 +64,10 @@ public final class RawRequest implements RawMessage {
     @Override
     public long getId() {
         return this.id;
+    }
+
+    public long getTTL() {
+        return ttl;
     }
 
     public String getService() {

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawResponse.java
@@ -22,6 +22,7 @@
 
 package com.uber.tchannel.schemes;
 
+import com.uber.tchannel.api.ResponseCode;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 
@@ -43,29 +44,20 @@ import java.util.Map;
 public final class RawResponse implements RawMessage {
 
     private final long id;
+    private final ResponseCode responseCode;
     private final Map<String, String> transportHeaders;
     private final ByteBuf arg1;
     private final ByteBuf arg2;
     private final ByteBuf arg3;
 
-    public RawResponse(long id, Map<String, String> transportHeaders, ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
+    public RawResponse(long id, ResponseCode responseCode, Map<String, String> transportHeaders, ByteBuf arg1,
+                       ByteBuf arg2, ByteBuf arg3) {
         this.id = id;
+        this.responseCode = responseCode;
         this.transportHeaders = transportHeaders;
         this.arg1 = arg1;
         this.arg2 = arg2;
         this.arg3 = arg3;
-    }
-
-    public ByteBuf getArg1() {
-        return arg1;
-    }
-
-    public ByteBuf getArg2() {
-        return arg2;
-    }
-
-    public ByteBuf getArg3() {
-        return arg3;
     }
 
     @Override
@@ -73,21 +65,28 @@ public final class RawResponse implements RawMessage {
         return this.id;
     }
 
+    public ResponseCode getResponseCode() {
+        return responseCode;
+    }
+
     @Override
     public Map<String, String> getTransportHeaders() {
         return this.transportHeaders;
     }
 
-    public ByteBuf getMethod() {
-        return this.arg1;
+    @Override
+    public ByteBuf getArg1() {
+        return arg1;
     }
 
-    public ByteBuf getApplicationHeaders() {
-        return this.arg2;
+    @Override
+    public ByteBuf getArg2() {
+        return arg2;
     }
 
-    public ByteBuf getBody() {
-        return this.arg3;
+    @Override
+    public ByteBuf getArg3() {
+        return arg3;
     }
 
     @Override

--- a/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
@@ -26,6 +26,7 @@ import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.CallRequestContinue;
 import com.uber.tchannel.messages.CallResponse;
 import com.uber.tchannel.messages.CallResponseContinue;
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 
@@ -61,7 +62,7 @@ public class Fixtures {
         return new CallResponse(
                 id,
                 moreFragments ? (byte) 1 : (byte) 0,
-                CallResponse.CallResponseCode.OK,
+                ResponseCode.OK,
                 new Trace(0, 0, 0, (byte) 0x00),
                 new HashMap<String, String>(),
                 ChecksumType.NoChecksum,

--- a/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
@@ -21,12 +21,12 @@
  */
 package com.uber.tchannel;
 
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.CallRequestContinue;
 import com.uber.tchannel.messages.CallResponse;
 import com.uber.tchannel.messages.CallResponseContinue;
-import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/BuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/BuilderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class BuilderTest {
+
+    @Test
+    public void testSetTTL() throws Exception {
+        long ttlInSeconds = 1;
+        Request<String> req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInSeconds, TimeUnit.SECONDS).build();
+        assertEquals(1000, req.getTTL());
+
+        long ttlInMicroseconds = 1000;
+
+        req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInMicroseconds, TimeUnit.MICROSECONDS).build();
+        assertEquals(1, req.getTTL());
+    }
+
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/RequestTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/RequestTest.java
@@ -35,10 +35,7 @@ public class RequestTest {
 
     @Test
     public void testGetBody() throws Exception {
-        Request<String> request = new Request.Builder<>("Hello, World!")
-                .setEndpoint("some-endpoint")
-                .setService("some-service")
-                .build();
+        Request<String> request = new Request.Builder<>("Hello, World!", "some-serice", "some-endpoint").build();
         assertNotNull(request);
         assertEquals(String.class, request.getBody().getClass());
         assertEquals("Hello, World!", request.getBody());
@@ -57,8 +54,7 @@ public class RequestTest {
 
                         assertEquals(requestBody, request.getBody());
 
-                        return new Response.Builder<>(responseBody)
-                                .setEndpoint(request.getEndpoint())
+                        return new Response.Builder<>(responseBody, request.getEndpoint(), ResponseCode.OK)
                                 .setHeaders(request.getHeaders())
                                 .build();
 
@@ -79,10 +75,7 @@ public class RequestTest {
 
         tchannel.listen();
 
-        Request<String> request = new Request.Builder<>(requestBody)
-                .setEndpoint("endpoint")
-                .setService("ping-service")
-                .build();
+        Request<String> request = new Request.Builder<>(requestBody, "ping-service", "endpoint").build();
 
         Promise<Response<Integer>> responsePromise = tchannel.callJSON(
                 tchannel.getHost(),
@@ -109,8 +102,7 @@ public class RequestTest {
             @Override
             public Response<String> handle(Request<String> request) {
                 assertEquals(requestBody, request.getBody());
-                return new Response.Builder<>(responseBody)
-                        .setEndpoint(request.getEndpoint())
+                return new Response.Builder<>(responseBody, request.getEndpoint(), ResponseCode.OK)
                         .setHeaders(request.getHeaders())
                         .build();
             }
@@ -126,10 +118,7 @@ public class RequestTest {
             }
         };
 
-        Request<String> request = new Request.Builder<>(requestBody)
-                .setService("some-service")
-                .setEndpoint("some-endpoint")
-                .build();
+        Request<String> request = new Request.Builder<>(requestBody, "some-service", "some-endpoint").build();
 
         Response<String> response = requestHandler.handle(request);
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
@@ -48,8 +48,8 @@ public class CancelCodecTest {
         Cancel newCancel = channel.readInbound();
 
         assertEquals(cancel.getId(), newCancel.getId());
-        assertEquals(cancel.getTtl(), newCancel.getTtl());
-        assertTrue(newCancel.getTtl() > 0);
+        assertEquals(cancel.getTTL(), newCancel.getTTL());
+        assertTrue(newCancel.getTTL() > 0);
         assertEquals(cancel.getTracing().traceId, newCancel.getTracing().traceId);
         assertEquals(cancel.getWhy(), newCancel.getWhy());
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/ClaimCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/ClaimCodecTest.java
@@ -46,7 +46,7 @@ public class ClaimCodecTest {
 
         Claim newClaimMessage = channel.readInbound();
         assertEquals(newClaimMessage.getId(), claimMessage.getId());
-        assertEquals(newClaimMessage.getTtl(), claimMessage.getTtl());
+        assertEquals(newClaimMessage.getTTL(), claimMessage.getTTL());
 
     }
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/MessageFragmenterTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/MessageFragmenterTest.java
@@ -62,6 +62,7 @@ public class MessageFragmenterTest {
 
         RawRequest rawRequest = new RawRequest(
                 0,
+                100,
                 "some-service",
                 null,
                 arg1,

--- a/tchannel-example/src/main/java/com/uber/tchannel/json/JsonClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/json/JsonClient.java
@@ -37,9 +37,9 @@ public class JsonClient {
         final TChannel tchannel = new TChannel.Builder("json-server").build();
 
         Promise<Response<ResponsePojo>> p = tchannel.callJSON(InetAddress.getLocalHost(), 8888, new Request.Builder<>(
-                        new RequestPojo(0, "hello?"))
-                        .setService("json-service")
-                        .setEndpoint("json-endpoint")
+                        new RequestPojo(0, "hello?"),
+                        "json-service",
+                        "json-endpoint")
                         .setTransportHeader(TransportHeaders.ARG_SCHEME_KEY, ArgScheme.JSON.getScheme())
                         .build(),
                 ResponsePojo.class

--- a/tchannel-example/src/main/java/com/uber/tchannel/json/JsonReqeustHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/json/JsonReqeustHandler.java
@@ -25,14 +25,14 @@ package com.uber.tchannel.json;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.RequestHandler;
 import com.uber.tchannel.api.Response;
+import com.uber.tchannel.api.ResponseCode;
 
 public class JsonReqeustHandler implements RequestHandler<RequestPojo, ResponsePojo> {
     @Override
     public Response<ResponsePojo> handle(Request<RequestPojo> request) {
         System.out.println(request);
 
-        return new Response.Builder<>(new ResponsePojo(true, "hi!"))
-                .setEndpoint(request.getEndpoint())
+        return new Response.Builder<>(new ResponsePojo(true, "hi!"), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .setTransportHeaders(request.getTransportHeaders())
                 .build();

--- a/tchannel-example/src/main/java/com/uber/tchannel/ping/PingClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/ping/PingClient.java
@@ -86,10 +86,8 @@ public class PingClient {
             }
         };
 
-        Request<Ping> request = new Request.Builder<>(new Ping("{'key': 'ping?'}"))
-                .setEndpoint("ping")
+        Request<Ping> request = new Request.Builder<>(new Ping("{'key': 'ping?'}"), "some-service", "ping")
                 .setHeaders(headers)
-                .setService("some-service")
                 .build();
 
         for (int i = 0; i < this.requests; i++) {

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueHandler.java
@@ -25,6 +25,7 @@ package com.uber.tchannel.thrift;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.RequestHandler;
 import com.uber.tchannel.api.Response;
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.thrift.generated.KeyValue;
 import com.uber.tchannel.thrift.generated.NotFoundError;
 
@@ -49,8 +50,7 @@ public class GetValueHandler implements RequestHandler<KeyValue.getValue_args, K
             err = new NotFoundError(key);
         }
 
-        return new Response.Builder<>(new KeyValue.getValue_result(value, err))
-                .setEndpoint(request.getEndpoint())
+        return new Response.Builder<>(new KeyValue.getValue_result(value, err), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .setTransportHeaders(request.getTransportHeaders())
                 .build();

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
@@ -66,10 +66,7 @@ public class KeyValueClient {
         Promise<Response<KeyValue.setValue_result>> setPromise = tchannel.callThrift(
                 InetAddress.getLocalHost(),
                 8888,
-                new Request.Builder<>(setValue)
-                        .setService("keyvalue-service")
-                        .setEndpoint("KeyValue::setValue")
-                        .build(),
+                new Request.Builder<>(setValue, "keyvalue-service", "KeyValue::setValue").build(),
                 KeyValue.setValue_result.class
         );
 
@@ -86,10 +83,7 @@ public class KeyValueClient {
         Promise<Response<KeyValue.getValue_result>> getPromise = tchannel.callThrift(
                 InetAddress.getLocalHost(),
                 8888,
-                new Request.Builder<>(getValue)
-                        .setService("keyvalue-service")
-                        .setEndpoint("KeyValue::getValue")
-                        .build(),
+                new Request.Builder<>(getValue, "keyvalue-service", "KeyValue::getValue").build(),
                 KeyValue.getValue_result.class
         );
 

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueHandler.java
@@ -25,6 +25,7 @@ package com.uber.tchannel.thrift;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.RequestHandler;
 import com.uber.tchannel.api.Response;
+import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.thrift.generated.KeyValue;
 
 import java.util.Map;
@@ -45,8 +46,7 @@ public class SetValueHandler implements RequestHandler<KeyValue.setValue_args, K
 
         this.keyValueStore.put(key, value);
 
-        return new Response.Builder<>(new KeyValue.setValue_result())
-                .setEndpoint(request.getEndpoint())
+        return new Response.Builder<>(new KeyValue.setValue_result(), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .setTransportHeaders(request.getTransportHeaders())
                 .build();


### PR DESCRIPTION
Why
====
We weren't exposing Request TTLs nor Response Error code.

Misc
====
- Move required fields for Request and Response to the constructor
- Definitely needs more tests…