### PR TITLE
Enable setting host on a TChannel listener.

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -162,7 +162,7 @@ public final class TChannel {
 
         private final String service;
         private final ChannelManager channelManager = new ChannelManager();
-        private final InetAddress host;
+        private InetAddress host;
         private int port = 0;
         private Map<String, RequestHandler> requestHandlers = new HashMap<>();
         private EventLoopGroup bossGroup = new NioEventLoopGroup(1);
@@ -175,6 +175,11 @@ public final class TChannel {
             }
             this.service = service;
             this.host = InetAddress.getLocalHost();
+        }
+
+        public Builder setServerHost(InetAddress host) {
+            this.host = host;
+            return this;
         }
 
         public Builder setServerPort(int port) throws UnknownHostException {

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/RequestBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/RequestBuilderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class RequestBuilderTest {
+
+    @Test
+    public void testSetTTL() throws Exception {
+        long ttlInSeconds = 1;
+        Request<String> req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInSeconds, TimeUnit.SECONDS).build();
+        assertEquals(1000, req.getTTL());
+
+        long ttlInMicroseconds = 1000;
+
+        req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInMicroseconds, TimeUnit.MICROSECONDS).build();
+        assertEquals(1, req.getTTL());
+    }
+
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
@@ -24,22 +24,22 @@ package com.uber.tchannel.api;
 
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
+import java.net.InetAddress;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
-public class BuilderTest {
+public class TChannelBuilderTest {
 
     @Test
-    public void testSetTTL() throws Exception {
-        long ttlInSeconds = 1;
-        Request<String> req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInSeconds, TimeUnit.SECONDS).build();
-        assertEquals(1000, req.getTTL());
+    public void testSetServerHost() throws Exception {
 
-        long ttlInMicroseconds = 1000;
+        TChannel tchannel = new TChannel.Builder("some-service")
+                .setServerHost(InetAddress.getLoopbackAddress())
+                .build();
+        tchannel.listen();
+        assertEquals("localhost", tchannel.getHost().getCanonicalHostName());
+        tchannel.shutdown();
 
-        req = new Request.Builder<>("foo", "bar", "baz").setTTL(ttlInMicroseconds, TimeUnit.MICROSECONDS).build();
-        assertEquals(1, req.getTTL());
     }
 
 }


### PR DESCRIPTION
This feature is primarily for consumers who would like to explicitly set
the hostname of the listener, or for those who want to listen on a
Loopback address.

Fixes #54 

cc @truncs @brandoniles 