### PR TITLE
Prepare Project for Maven Central Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ System.out.println(response);
 #### PingServer
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer -p 8888
+java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer -p 8888
 ```
 
 #### PingClient
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient -h localhost -p 8888 -n 1000
+java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient -h localhost -p 8888 -n 1000
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ System.out.println(response);
 #### PingServer
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer -p 8888
+java -cp tchannel-example/target/tchannel-example.jar com.uber.tchannel.ping.PingServer -p 8888
 ```
 
 #### PingClient
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient -h localhost -p 8888 -n 1000
+java -cp tchannel-example/target/tchannel-example.jar com.uber.tchannel.ping.PingClient -h localhost -p 8888 -n 1000
 ```
 
 ## Contributing

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.uber.tchannel</groupId>
-    <artifactId>tchannel-java</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <artifactId>tchannel</artifactId>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>tchannel-java</name>
+    <name>tchannel</name>
     <description>Network multiplexing and framing protocol for RPC</description>
     <url>https://github.com/uber/tchannel-java</url>
 
@@ -43,8 +43,8 @@
 
     <developers>
         <developer>
-            <name>Will Salisbury</name>
-            <email>wjs@uber.com</email>
+            <name>Uber</name>
+            <email>dev@uber.com</email>
             <organization>Uber Technologies, Inc.</organization>
             <organizationUrl>https://uber.github.io</organizationUrl>
         </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,36 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.uber.tchannel</groupId>
-    <artifactId>tchannel</artifactId>
+    <artifactId>tchannel-java</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+
+    <name>tchannel-java</name>
+    <description>Network multiplexing and framing protocol for RPC</description>
+    <url>https://github.com/uber/tchannel-java</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Will Salisbury</name>
+            <email>wjs@uber.com</email>
+            <organization>Uber Technologies, Inc.</organization>
+            <organizationUrl>https://uber.github.io</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git@github.com:uber/tchannel-java.git</connection>
+        <developerConnection>scm:git:git@github.com:uber/tchannel-java.git</developerConnection>
+        <url>git@github.com:uber/tchannel-java.git</url>
+    </scm>
+
     <modules>
         <module>tchannel-core</module>
         <module>tchannel-example</module>
@@ -43,17 +70,19 @@
 
     <build>
         <plugins>
+            <!-- Compiler Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <testSource>1.7</testSource>
-                    <testTarget>1.7</testTarget>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <testSource>${maven.compiler.source}</testSource>
+                    <testTarget>${maven.compiler.target}</testTarget>
                 </configuration>
             </plugin>
+            <!-- Checkstyle Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -74,8 +103,122 @@
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <!--
+                    http://central.sonatype.org/pages/apache-maven.html
+                    Distribution Management and Authentication
+                    -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!--
+                   http://central.sonatype.org/pages/apache-maven.html
+                   Distribution Management and Authentication
+                   -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+
+                    <!--
+                    http://central.sonatype.org/pages/apache-maven.html
+                    Performing a Release Deployment with the Maven Release Plugin
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <useReleaseProfile>false</useReleaseProfile>
+                            <releaseProfiles>release</releaseProfiles>
+                            <goals>deploy</goals>
+                        </configuration>
+                    </plugin>
+
+                    <!--
+                    http://central.sonatype.org/pages/apache-maven.html
+                    GPG Signed Components
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                    http://central.sonatype.org/pages/apache-maven.html
+                    Javadoc and Sources Attachments
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 
     <dependencies>
         <dependency>
@@ -95,5 +238,17 @@
             <version>1.3.1</version>
         </dependency>
     </dependencies>
+
+    <!--
+    http://central.sonatype.org/pages/apache-maven.html
+    Distribution Management and Authentication
+    -->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
 
     <developers>
         <developer>
-            <name>Uber</name>
-            <email>dev@uber.com</email>
+            <name>Will Salisbury</name>
+            <email>wjs@uber.com</email>
             <organization>Uber Technologies, Inc.</organization>
             <organizationUrl>https://uber.github.io</organizationUrl>
         </developer>

--- a/tchannel-benchmark/README.md
+++ b/tchannel-benchmark/README.md
@@ -7,7 +7,7 @@ Running the Benchmarks
 ```bash
 cd tchannel-benchmarks/
 mvn clean install
-java -jar target/benchmarks.jar
+java -jar target/tchannel-benchmark.jar
 ```
 
 ## MIT Licenced

--- a/tchannel-benchmark/pom.xml
+++ b/tchannel-benchmark/pom.xml
@@ -32,9 +32,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel-java</artifactId>
+        <artifactId>tchannel</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -67,7 +67,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/tchannel-benchmark/pom.xml
+++ b/tchannel-benchmark/pom.xml
@@ -75,7 +75,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.10.3</jmh.version>
         <javac.target>1.7</javac.target>
-        <uberjar.name>tchannel-benchmark</uberjar.name>
     </properties>
 
     <build>
@@ -101,7 +100,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>${uberjar.name}</finalName>
+                            <finalName>${artifactId}</finalName>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/tchannel-benchmark/pom.xml
+++ b/tchannel-benchmark/pom.xml
@@ -32,16 +32,16 @@ THE POSSIBILITY OF SUCH DAMAGE.
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel</artifactId>
+        <artifactId>tchannel-java</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tchannel-benchmark</artifactId>
     <packaging>jar</packaging>
 
-    <name>JMH benchmark sample: Java</name>
+    <name>tchannel-benchmark</name>
 
     <!--
        This is the demo/sample template build script for building Java benchmarks with JMH.
@@ -67,7 +67,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -75,7 +75,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.10.3</jmh.version>
         <javac.target>1.7</javac.target>
-        <uberjar.name>benchmarks</uberjar.name>
+        <uberjar.name>tchannel-benchmark</uberjar.name>
     </properties>
 
     <build>

--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -24,9 +24,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel</artifactId>
+        <artifactId>tchannel-java</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -24,9 +24,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel-java</artifactId>
+        <artifactId>tchannel</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tchannel-example/README.md
+++ b/tchannel-example/README.md
@@ -6,7 +6,7 @@ Running the Examples
 
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer 8888
+java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer 8888
 # Starting server on port: 8888
 # Jul 29, 2015 10:28:07 AM io.netty.handler.logging.LoggingHandler channelRegistered
 # INFO: [id: 0x8b9e9085] REGISTERED
@@ -19,7 +19,7 @@ java -cp tchannel-example/target/tchannel-example-1.0-SNAPSHOT.jar com.uber.tcha
 #### PingClient
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient 8888
+java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient 8888
 #Connecting from client to server on port: 8888
 #<RawResponse id=42 transportHeaders={as=json} arg1=ping arg2={} arg3={"response":"pong!"}>
 #Stopping Client...

--- a/tchannel-example/README.md
+++ b/tchannel-example/README.md
@@ -6,7 +6,7 @@ Running the Examples
 
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingServer 8888
+java -cp tchannel-example/target/tchannel-example.jar com.uber.tchannel.ping.PingServer --port 8888
 # Starting server on port: 8888
 # Jul 29, 2015 10:28:07 AM io.netty.handler.logging.LoggingHandler channelRegistered
 # INFO: [id: 0x8b9e9085] REGISTERED
@@ -19,7 +19,7 @@ java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tc
 #### PingClient
 ```bash
 mvn package
-java -cp tchannel-example/target/tchannel-example-0.1.0-SNAPSHOT.jar com.uber.tchannel.ping.PingClient 8888
+java -cp tchannel-example/target/tchannel-example.jar com.uber.tchannel.ping.PingClient --port 8888
 #Connecting from client to server on port: 8888
 #<RawResponse id=42 transportHeaders={as=json} arg1=ping arg2={} arg3={"response":"pong!"}>
 #Stopping Client...

--- a/tchannel-example/pom.xml
+++ b/tchannel-example/pom.xml
@@ -24,9 +24,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel</artifactId>
+        <artifactId>tchannel-java</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/tchannel-example/pom.xml
+++ b/tchannel-example/pom.xml
@@ -24,9 +24,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel-java</artifactId>
+        <artifactId>tchannel</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/tchannel-example/pom.xml
+++ b/tchannel-example/pom.xml
@@ -50,13 +50,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.6</version>
+                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <finalName>${artifactId}</finalName>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/tchannel-hyperbahn/pom.xml
+++ b/tchannel-hyperbahn/pom.xml
@@ -3,9 +3,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel</artifactId>
+        <artifactId>tchannel-java</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/tchannel-hyperbahn/pom.xml
+++ b/tchannel-hyperbahn/pom.xml
@@ -3,9 +3,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tchannel-java</artifactId>
+        <artifactId>tchannel</artifactId>
         <groupId>com.uber.tchannel</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.uber.tchannel</groupId>
             <artifactId>tchannel-core</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Why
====
We would like to provide `tchannel-java` as a package that is easily integrated into traditional Java Maven projects e.g. Hosted in a Central Repository.


What
====
Since one cannot simply upload a project to Maven Central, we need to go
through a 3rd party 'host'. There are a few available but it appears as
though both Netty and Google Guava use Sonatype so I went with them.
There are a few requirements, and the full guide lives here:
http://central.sonatype.org/pages/ossrh-guide.html.

Misc
------
- Update the artifactId to `tchannel-java`
- Move versiont to SemVer
- Update docs everywhere
- Change tchannel-benchmark name to `tchannel-benchmark` from the
  generic name from the JMH template

reviewers: @truncs @brandoniles @zsong03
cc: @sectioneight @jwolski 