### PR TITLE
fix the concurrency model of ResponseRouter that results in NullPoint…

### DIFF
--- a/tchannel-benchmark/README.md
+++ b/tchannel-benchmark/README.md
@@ -5,7 +5,7 @@ Running the Benchmarks
 ----------------------
 
 ```bash
-cd tchannel-benchmarks/
+cd tchannel-benchmark/
 mvn clean install
 java -cp "target/*" com.uber.tchannel.benchmarks.PingPongServerBenchmark
 ```

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
@@ -39,11 +39,12 @@ import io.netty.util.concurrent.Promise;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ResponseRouter extends SimpleChannelInboundHandler<RawResponse> {
 
-    private final Map<Long, ResponsePromise> messageMap = new HashMap<>();
+    private final Map<Long, ResponsePromise> messageMap = new ConcurrentHashMap<>();
     private final Serializer serializer = new Serializer(new HashMap<ArgScheme, Serializer.SerializerInterface>() {
         {
             put(ArgScheme.JSON, new JSONSerializer());
@@ -78,7 +79,7 @@ public class ResponseRouter extends SimpleChannelInboundHandler<RawResponse> {
 
         Promise<Response<T>> responsePromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
         this.messageMap.put(rawRequest.getId(), new ResponsePromise<>(responsePromise, responseType));
-        ctx.writeAndFlush(rawRequest).await();
+        ctx.writeAndFlush(rawRequest);
         return responsePromise;
     }
 


### PR DESCRIPTION
resolves #53  

Here's the entire explanation of the problem 

Netty guarantees that a ChannelHandler will be handled by a Executor with fixed set of Threads (changed in 5.0 before this it was one Thread per ChannelHandler) and also guarantees that the it won't be accessed concurrently and somehow manages the variables to be consistent across the given set of Threads held by the executor (by guess it has its own version of ChannelLocal similar to ThreadLocal).

These guarantees go away when a ChannelHandler is used outside the context of Netty which was the case with ResponseRouter since call methods were accessing it outside the context of Netty and hence the messageMap had inconsistent values across the two threads. 


```
Queued <RawRequest id=9 service=some-service transportHeaders={as=json, cn=ping-client} arg1=ping arg2={} arg3={"request":"ping?"}> ChannelHandlerContext(ResponseRouter,            [id: 0x8c78ba72, /10.32.166.102:53491 => europa-13.local/10.32.166.102:53490]) Thread: 12

Success <RawResponse id=90 transportHeaders={as=json, cn=ping-client} arg1=ping arg2={} arg3={"response":"pong!"}> ChannelHandlerContext(ResponseRouter, [id: 0x8c78ba72, /10.       32.166.102:53491 => europa-13.local/10.32.166.102:53490]) Thread: 17
```
From the above log its pretty clear that the thread queuing the values in the messageMap is thread: 12 and the thread removing from it thread: 17, which is what causes the inconsistencies. 

The other change remove await which is not really required and all it was doing earlier was reducing the probability of the NullPointerException.

This also results in improved QPS on the response queuing side as much as 400x is some cases ! 

Before Benchmark:
```
Benchmark                                    (sleepTime)   Mode  Cnt     Score     Error  Units
PingPongServerBenchmark.benchmark                      0  thrpt   10  7469.815 ± 803.796  ops/s
PingPongServerBenchmark.benchmark:actualQPS            0  thrpt   10  7397.594 ± 985.218  ops/s
PingPongServerBenchmark.benchmark                      1  thrpt   10   766.573 ± 234.731  ops/s
PingPongServerBenchmark.benchmark:actualQPS            1  thrpt   10   744.960 ±  27.373  ops/s
PingPongServerBenchmark.benchmark                     10  thrpt   10    83.319 ±  21.779  ops/s
PingPongServerBenchmark.benchmark:actualQPS           10  thrpt   10    86.660 ±   0.757  ops/s
```

After Benchmark:

```
# Run complete. Total time: 00:02:10

Benchmark                                    (sleepTime)   Mode  Cnt      Score       Error  Units
PingPongServerBenchmark.benchmark                      0  thrpt   10  22743.757 ±  8792.381  ops/s
PingPongServerBenchmark.benchmark:actualQPS            0  thrpt   10   7420.606 ±  2772.464  ops/s
PingPongServerBenchmark.benchmark                      1  thrpt   10  30050.651 ± 11778.476  ops/s
PingPongServerBenchmark.benchmark:actualQPS            1  thrpt   10    728.472 ±   278.103  ops/s
PingPongServerBenchmark.benchmark                     10  thrpt   10  32986.252 ±  5484.128  ops/s
PingPongServerBenchmark.benchmark:actualQPS           10  thrpt   10     87.853 ±     6.092  ops/s
```

Although there might better way to do this as mentioned in #67 lets do this for now to unblock other people.

cc @willsalz @brandoniles 