### PR TITLE
Make handlers execute on a separate thread

### DIFF
--- a/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongServerBenchmark.java
+++ b/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongServerBenchmark.java
@@ -75,6 +75,7 @@ public class PingPongServerBenchmark {
 
         this.channel = new TChannel.Builder("ping-server")
                 .register("ping", new PingDefaultRequestHandler())
+                .setMaxQueuedRequests(20000000)
                 .build();
         this.client = new TChannel.Builder("ping-client").build();
         channel.listen();

--- a/tchannel-core/src/main/java/com/uber/tchannel/errors/BusyError.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/errors/BusyError.java
@@ -20,44 +20,34 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.headers;
+package com.uber.tchannel.errors;
 
-public enum ArgScheme {
-    RAW("raw"),
-    JSON("json"),
-    HTTP("http"),
-    THRIFT("thrift"),
-    STREAMING_THRIFT("sthrift");
+import com.uber.tchannel.tracing.Trace;
 
-    private final String scheme;
+public class BusyError extends ProtocolError {
+    private static final ErrorType errorType = ErrorType.Busy;
+    private final Trace trace;
+    private final long id;
 
-    ArgScheme(String scheme) {
-
-        this.scheme = scheme;
+    public BusyError(String message, Trace trace, long id) {
+        super(message);
+        this.trace = trace;
+        this.id = id;
     }
 
-    public static ArgScheme toScheme(String argScheme) {
-        if (argScheme == null) {
-            return null;
-        }
-
-        switch (argScheme) {
-            case "raw":
-                return RAW;
-            case "json":
-                return JSON;
-            case "http":
-                return HTTP;
-            case "thrift":
-                return THRIFT;
-            case "sthrift":
-                return STREAMING_THRIFT;
-            default:
-                return null;
-        }
+    @Override
+    public long getId() {
+        return id;
     }
 
-    public String getScheme() {
-        return scheme;
+    @Override
+    public ErrorType getErrorType() {
+        return errorType;
     }
+
+    @Override
+    public Trace getTrace() {
+        return trace;
+    }
+
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
@@ -25,6 +25,7 @@ package com.uber.tchannel.schemes;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -55,7 +56,7 @@ public final class RawRequest implements RawMessage {
         this.id = id;
         this.ttl = ttl;
         this.service = service;
-        this.transportHeaders = transportHeaders;
+        this.transportHeaders = transportHeaders != null ? transportHeaders : new HashMap<String, String>();
         this.arg1 = arg1;
         this.arg2 = arg2;
         this.arg3 = arg3;

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestRequestRouter.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestRequestRouter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.tchannel.handlers;
+
+import com.uber.tchannel.errors.BadRequestError;
+import com.uber.tchannel.errors.BusyError;
+import com.uber.tchannel.headers.ArgScheme;
+import com.uber.tchannel.headers.TransportHeaders;
+import com.uber.tchannel.schemes.RawRequest;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+public class TestRequestRouter {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testBadRequestErrorOnMissingArgScheme() {
+        thrown.expect(BadRequestError.class);
+
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new RequestRouter(null, Executors.newFixedThreadPool(1), 0)
+        );
+
+        RawRequest rawRequest= new RawRequest(1, 1, null, null, null, null, null);
+        channel.writeInbound(rawRequest);
+
+    }
+
+    @Test
+    public void testBadRequestErrorOnInvalidArgScheme() {
+        thrown.expect(BadRequestError.class);
+
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new RequestRouter(null, Executors.newFixedThreadPool(1), 0)
+        );
+
+        Map<String, String> transportHeaders = new HashMap<String, String>();
+        transportHeaders.put(TransportHeaders.ARG_SCHEME_KEY, "foobar");
+
+        RawRequest rawRequest= new RawRequest(1, 1, null, transportHeaders, null, null, null);
+        channel.writeInbound(rawRequest);
+    }
+
+    @Test
+    public void testRateLimiting() {
+        thrown.expect(BusyError.class);
+
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new RequestRouter(null, Executors.newFixedThreadPool(1), 0)
+        );
+
+        Map<String, String> transportHeaders = new HashMap<String, String>();
+        transportHeaders.put(TransportHeaders.ARG_SCHEME_KEY, ArgScheme.HTTP.getScheme());
+
+        RawRequest rawRequest= new RawRequest(1, 1, null, transportHeaders, null, null, null);
+        channel.writeInbound(rawRequest);
+    }
+}


### PR DESCRIPTION
This add concurrency to the RequestRouter so that  it doesn't block the networking threads. The things that are important in the pull request are

## Things to look at

 - Adds a parameter called maxQueuedRequests which by default is set to the num of processor * 5
 - Adds a parameter to take the executor service, which by default is a ForkJoinPool
 - Adds a class for BusyError thrown when the current queued request exceeds the maxQueuedRequests
 - Fixes a NullPointerException in the RequestRouter handler when the argscheme is missing
 - Adds test cases for BadRequestError and BusyError

## Things that are missing
 - Queue draining is being tracked at #71 
 - Making handlers to return a Future as well is being tracked at #72  