### PR TITLE
change the tchannel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Request<Ping> request = new Request.Builder<>(new Ping("ping?"))
 	.build();
 
 // Make an asynchronous request
-Promise<Response<Pong>> responseFuture = tchannel.callJSON(
+ListenableFuture<Response<Pong>> responseFuture = tchannel.callJSON(
 	tchannel.getHost(),
 	tchannel.getListeningPort(),
 	"service",

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/DefaultTypedRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/DefaultTypedRequestHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api.handlers;
+
+import com.google.common.reflect.TypeToken;
+import com.uber.tchannel.api.Request;
+import com.uber.tchannel.api.Response;
+import com.uber.tchannel.schemes.RawRequest;
+import com.uber.tchannel.schemes.RawResponse;
+import com.uber.tchannel.schemes.Serializer;
+
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+
+public abstract class DefaultTypedRequestHandler<T, U, V extends Serializer.SerializerInterface>
+        implements RequestHandler {
+
+    private TypeToken<T> requestType = new TypeToken<T>(getClass()) { };
+    private TypeToken<U> responseType = new TypeToken<U>(getClass()) { };
+    private TypeToken<V> serializerType = new TypeToken<V>(getClass()) { };
+
+    private V serializer = getSerializerInstance();
+
+    @Override
+    public RawResponse handle(RawRequest request) {
+
+        Request<T> requestT = new Request.Builder<>(
+                serializer.decodeBody(request.getArg3(), this.getRequestType()),
+                request.getService(),
+                serializer.decodeEndpoint(request.getArg1()))
+                .setHeaders(serializer.decodeHeaders(request.getArg2()))
+                .setTransportHeaders(request.getTransportHeaders())
+                .setTTL(request.getTTL())
+                .build();
+
+        Response<U> responseU = handleImpl(requestT);
+
+        Map<String, String> transportHeaders = responseU.getTransportHeaders();
+        transportHeaders = transportHeaders.isEmpty() ? requestT.getTransportHeaders() : transportHeaders;
+
+        RawResponse response = new RawResponse(
+                request.getId(),
+                responseU.getResponseCode(),
+                transportHeaders,
+                serializer.encodeEndpoint(responseU.getEndpoint()),
+                serializer.encodeHeaders(responseU.getHeaders()),
+                serializer.encodeBody(responseU.getBody())
+        );
+
+        return response;
+    }
+
+    private Class<T> getRequestType() {
+        return (Class<T>) requestType.getRawType();
+    }
+
+    private Class<U> getResponseType() {
+        return (Class<U>) responseType.getRawType();
+    }
+
+    private V getSerializerInstance() {
+        V instance = null;
+        try {
+            instance = ((Class<V>) serializerType.getRawType()).newInstance();
+        } catch (Exception exception) {
+            throw new ServiceConfigurationError("Unable to instantiate a serializer");
+        }
+        return instance;
+    }
+
+    public abstract Response<U> handleImpl(Request<T> requestT);
+}
+

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/JSONRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/JSONRequestHandler.java
@@ -20,18 +20,8 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.json;
+package com.uber.tchannel.api.handlers;
 
-import com.uber.tchannel.api.Request;
-import com.uber.tchannel.api.Response;
-import com.uber.tchannel.api.ResponseCode;
-import com.uber.tchannel.api.handlers.JSONRequestHandler;
+import com.uber.tchannel.schemes.JSONSerializer;
 
-public class JsonDefaultRequestHandler extends JSONRequestHandler<RequestPojo, ResponsePojo> {
-
-    public Response<ResponsePojo> handleImpl(Request<RequestPojo> request) {
-        System.out.println(request);
-
-        return new Response.Builder<>(new ResponsePojo(true, "hi!"), request.getEndpoint(), ResponseCode.OK).build();
-    }
-}
+public abstract class JSONRequestHandler<T, U> extends DefaultTypedRequestHandler<T, U, JSONSerializer> { }

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/RequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/RequestHandler.java
@@ -20,11 +20,12 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.api;
+package com.uber.tchannel.api.handlers;
 
-public interface RequestHandler<T, U> {
-    Response<U> handle(Request<T> request);
-    Class<T> getRequestType();
-    Class<U> getResponseType();
+import com.uber.tchannel.schemes.RawRequest;
+import com.uber.tchannel.schemes.RawResponse;
+
+public interface RequestHandler {
+    RawResponse handle(RawRequest request);
 
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftRequestHandler.java
@@ -20,22 +20,8 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.api;
+package com.uber.tchannel.api.handlers;
 
-import com.google.common.reflect.TypeToken;
+import com.uber.tchannel.schemes.ThriftSerializer;
 
-public abstract class DefaultRequestHandler<T, U> implements RequestHandler<T, U> {
-
-    private TypeToken<T> requestType = new TypeToken<T>(getClass()) { };
-    private TypeToken<U> responseType = new TypeToken<U>(getClass()) { };
-
-    @Override
-    public Class<T> getRequestType() {
-        return (Class<T>) requestType.getRawType();
-    }
-
-    @Override
-    public Class<U> getResponseType() {
-        return (Class<U>) responseType.getRawType();
-    }
-}
+public abstract class ThriftRequestHandler<T, U> extends DefaultTypedRequestHandler<T, U, ThriftSerializer> { }

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -69,7 +69,7 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
             CallRequest callRequest = new CallRequest(
                     rawRequest.getId(),
                     flags,
-                    0,
+                    rawRequest.getTTL(),
                     new Trace(0, 0, 0, (byte) 0x00),
                     rawRequest.getService(),
                     rawRequest.getTransportHeaders(),

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public final class RawRequest implements RawMessage {
 
-    private final long id;
+    private long id;
     private final long ttl;
     private final String service;
     private final Map<String, String> transportHeaders;
@@ -62,9 +62,23 @@ public final class RawRequest implements RawMessage {
         this.arg3 = arg3;
     }
 
+    public RawRequest(long ttl, String service, Map<String, String> transportHeaders,
+                      ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
+        this.ttl = ttl;
+        this.service = service;
+        this.transportHeaders = transportHeaders != null ? transportHeaders : new HashMap<String, String>();
+        this.arg1 = arg1;
+        this.arg2 = arg2;
+        this.arg3 = arg3;
+    }
+
     @Override
     public long getId() {
         return this.id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
     }
 
     public long getTTL() {
@@ -73,6 +87,10 @@ public final class RawRequest implements RawMessage {
 
     public String getService() {
         return this.service;
+    }
+
+    public void setTransportHeader(String header, String value) {
+        this.transportHeaders.put(header, value);
     }
 
     @Override

--- a/tchannel-example/src/main/java/com/uber/tchannel/json/JsonClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/json/JsonClient.java
@@ -22,12 +22,12 @@
 
 package com.uber.tchannel.json;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.headers.ArgScheme;
 import com.uber.tchannel.headers.TransportHeaders;
-import io.netty.util.concurrent.Promise;
 
 import java.net.InetAddress;
 
@@ -36,7 +36,8 @@ public class JsonClient {
     public static void main(String[] args) throws Exception {
         final TChannel tchannel = new TChannel.Builder("json-server").build();
 
-        Promise<Response<ResponsePojo>> p = tchannel.callJSON(InetAddress.getLocalHost(), 8888, new Request.Builder<>(
+        ListenableFuture<Response<ResponsePojo>> p = tchannel.callJSON(InetAddress.getLocalHost(), 8888,
+                new Request.Builder<>(
                         new RequestPojo(0, "hello?"),
                         "json-service",
                         "json-endpoint")

--- a/tchannel-example/src/main/java/com/uber/tchannel/ping/PingDefaultRequestHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/ping/PingDefaultRequestHandler.java
@@ -23,19 +23,16 @@
 package com.uber.tchannel.ping;
 
 import com.uber.tchannel.api.Request;
-import com.uber.tchannel.api.DefaultRequestHandler;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.handlers.JSONRequestHandler;
 
-public class PingDefaultRequestHandler extends DefaultRequestHandler<Ping, Pong> {
+public class PingDefaultRequestHandler extends JSONRequestHandler<Ping, Pong> {
 
-    @Override
-    public Response<Pong> handle(Request<Ping> request) {
-
+    public Response<Pong> handleImpl(Request<Ping> request) {
         return new Response.Builder<>(new Pong("pong!"), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .build();
-
     }
 
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueHandlerDefault.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueHandlerDefault.java
@@ -23,15 +23,15 @@
 package com.uber.tchannel.thrift;
 
 import com.uber.tchannel.api.Request;
-import com.uber.tchannel.api.DefaultRequestHandler;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.handlers.ThriftRequestHandler;
 import com.uber.tchannel.thrift.generated.KeyValue;
 import com.uber.tchannel.thrift.generated.NotFoundError;
 
 import java.util.Map;
 
-public class GetValueHandlerDefault extends DefaultRequestHandler<KeyValue.getValue_args, KeyValue.getValue_result> {
+public class GetValueHandlerDefault extends ThriftRequestHandler<KeyValue.getValue_args, KeyValue.getValue_result> {
 
     protected final Map<String, String> keyValueStore;
 
@@ -39,8 +39,7 @@ public class GetValueHandlerDefault extends DefaultRequestHandler<KeyValue.getVa
         this.keyValueStore = keyValueStore;
     }
 
-    @Override
-    public Response<KeyValue.getValue_result> handle(Request<KeyValue.getValue_args> request) {
+    public Response<KeyValue.getValue_result> handleImpl(Request<KeyValue.getValue_args> request) {
         String key = request.getBody().getKey();
 
         String value = this.keyValueStore.get(key);
@@ -50,9 +49,8 @@ public class GetValueHandlerDefault extends DefaultRequestHandler<KeyValue.getVa
             err = new NotFoundError(key);
         }
 
-        return new Response.Builder<>(new KeyValue.getValue_result(value, err), request.getEndpoint(), ResponseCode.OK)
-                .setHeaders(request.getHeaders())
-                .setTransportHeaders(request.getTransportHeaders())
+        return new Response.Builder<>(
+                new KeyValue.getValue_result(value, err), request.getEndpoint(), ResponseCode.OK)
                 .build();
     }
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
@@ -22,12 +22,12 @@
 
 package com.uber.tchannel.thrift;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.thrift.generated.KeyValue;
 import com.uber.tchannel.thrift.generated.NotFoundError;
-import io.netty.util.concurrent.Promise;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -63,14 +63,14 @@ public class KeyValueClient {
     public static void setValue(TChannel tchannel, String key, String value) throws Exception {
         KeyValue.setValue_args setValue = new KeyValue.setValue_args(key, value);
 
-        Promise<Response<KeyValue.setValue_result>> setPromise = tchannel.callThrift(
+        ListenableFuture<Response<KeyValue.setValue_result>> future = tchannel.callThrift(
                 InetAddress.getLocalHost(),
                 8888,
                 new Request.Builder<>(setValue, "keyvalue-service", "KeyValue::setValue").build(),
                 KeyValue.setValue_result.class
         );
 
-        setPromise.get(100, TimeUnit.MILLISECONDS);
+        future.get(100, TimeUnit.MILLISECONDS);
     }
 
     public static String getValue(
@@ -80,14 +80,14 @@ public class KeyValueClient {
 
         KeyValue.getValue_args getValue = new KeyValue.getValue_args(key);
 
-        Promise<Response<KeyValue.getValue_result>> getPromise = tchannel.callThrift(
+        ListenableFuture<Response<KeyValue.getValue_result>> future = tchannel.callThrift(
                 InetAddress.getLocalHost(),
                 8888,
                 new Request.Builder<>(getValue, "keyvalue-service", "KeyValue::getValue").build(),
                 KeyValue.getValue_result.class
         );
 
-        Response<KeyValue.getValue_result> getResult = getPromise.get(100, TimeUnit.MILLISECONDS);
+        Response<KeyValue.getValue_result> getResult = future.get(100, TimeUnit.MILLISECONDS);
 
         String value = getResult.getBody().getSuccess();
         NotFoundError err = getResult.getBody().getNotFound();

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueHandlerDefault.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueHandlerDefault.java
@@ -23,14 +23,14 @@
 package com.uber.tchannel.thrift;
 
 import com.uber.tchannel.api.Request;
-import com.uber.tchannel.api.DefaultRequestHandler;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.handlers.ThriftRequestHandler;
 import com.uber.tchannel.thrift.generated.KeyValue;
 
 import java.util.Map;
 
-public class SetValueHandlerDefault extends DefaultRequestHandler<KeyValue.setValue_args, KeyValue.setValue_result> {
+public class SetValueHandlerDefault extends ThriftRequestHandler<KeyValue.setValue_args, KeyValue.setValue_result> {
 
     private final Map<String, String> keyValueStore;
 
@@ -38,17 +38,13 @@ public class SetValueHandlerDefault extends DefaultRequestHandler<KeyValue.setVa
         this.keyValueStore = keyValueStore;
     }
 
-    @Override
-    public Response<KeyValue.setValue_result> handle(Request<KeyValue.setValue_args> request) {
+    public Response<KeyValue.setValue_result> handleImpl(Request<KeyValue.setValue_args> request) {
 
         String key = request.getBody().getKey();
         String value = request.getBody().getValue();
 
         this.keyValueStore.put(key, value);
 
-        return new Response.Builder<>(new KeyValue.setValue_result(), request.getEndpoint(), ResponseCode.OK)
-                .setHeaders(request.getHeaders())
-                .setTransportHeaders(request.getTransportHeaders())
-                .build();
+        return new Response.Builder<>(new KeyValue.setValue_result(), request.getEndpoint(), ResponseCode.OK).build();
     }
 }


### PR DESCRIPTION
This is an insanely huge diff, sorry about that. But this changes the call side and the server side APIs. 

## Things to look for
 - call side APIs now have ListenableFuture APIs
 - Its possible to send raw messages now, yay ! 
 - Seperates the RequestHandler into Handlers for each argscheme, they have a abstract handleImpl function
 - Serialization, Deserialization logic is completely remove from the network stack
 - The abstraction might be a little flawed since handleImpl takes the POJO instead of Request<POJO>
 - The same applies while returning handleImpl which returns a POJO instead of Response<POJO>

## Performance

### Current master
```
Benchmark                                    (sleepTime)   Mode  Cnt      Score      Error  Units
PingPongServerBenchmark.benchmark                      0  thrpt   10  26464.659 ± 7548.703  ops/s
PingPongServerBenchmark.benchmark:actualQPS            0  thrpt   10   9097.727 ± 2541.936  ops/s
PingPongServerBenchmark.benchmark                      1  thrpt   10  35650.153 ± 9012.003  ops/s
PingPongServerBenchmark.benchmark:actualQPS            1  thrpt   10    776.964 ±  171.012  ops/s
PingPongServerBenchmark.benchmark                     10  thrpt   10  34589.161 ± 4960.052  ops/s
PingPongServerBenchmark.benchmark:actualQPS           10  thrpt   10     87.028 ±    4.808  ops/s
```

### as-executor branch
```
Benchmark                                    (sleepTime)   Mode  Cnt      Score       Error  Units
PingPongServerBenchmark.benchmark                      0  thrpt   10  27938.489 ±  6079.643  ops/s
PingPongServerBenchmark.benchmark:actualQPS            0  thrpt   10  14699.715 ±  4896.936  ops/s
PingPongServerBenchmark.benchmark                      1  thrpt   10  24217.306 ±  9774.461  ops/s
PingPongServerBenchmark.benchmark:actualQPS            1  thrpt   10   5836.646 ±  2358.858  ops/s
PingPongServerBenchmark.benchmark                     10  thrpt   10  26417.658 ± 12571.757  ops/s
PingPongServerBenchmark.benchmark:actualQPS           10  thrpt   10    614.101 ±   289.005  ops/s
```

### This branch
```
Benchmark                                    (sleepTime)   Mode  Cnt      Score      Error  Units
PingPongServerBenchmark.benchmark                      0  thrpt   10  22155.933 ± 3621.052  ops/s
PingPongServerBenchmark.benchmark:actualQPS            0  thrpt   10  13143.591 ± 4300.413  ops/s
PingPongServerBenchmark.benchmark                      1  thrpt   10  21657.944 ± 5312.693  ops/s
PingPongServerBenchmark.benchmark:actualQPS            1  thrpt   10   6125.045 ± 1269.689  ops/s
PingPongServerBenchmark.benchmark                     10  thrpt   10  18847.220 ± 8568.649  ops/s
PingPongServerBenchmark.benchmark:actualQPS           10  thrpt   10    649.056 ±  300.511  ops/s
```