### PR TITLE
hyperbahn client first pass

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -69,7 +69,7 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
             CallRequest callRequest = new CallRequest(
                     rawRequest.getId(),
                     flags,
-                    0,
+                    rawRequest.getTTL(),
                     new Trace(0, 0, 0, (byte) 0x00),
                     rawRequest.getService(),
                     rawRequest.getTransportHeaders(),

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/JSONSerializer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/JSONSerializer.java
@@ -29,6 +29,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class JSONSerializer implements Serializer.SerializerInterface {
@@ -47,7 +48,8 @@ public final class JSONSerializer implements Serializer.SerializerInterface {
     public Map<String, String> decodeHeaders(ByteBuf arg2) {
         String headerJSON = arg2.toString(CharsetUtil.UTF_8);
         arg2.release();
-        return new Gson().fromJson(headerJSON, HEADER_TYPE);
+        Map<String, String> headers = new Gson().fromJson(headerJSON, HEADER_TYPE);
+        return (headers == null) ? new HashMap<String, String>() : headers;
     }
 
     @Override

--- a/tchannel-example/pom.xml
+++ b/tchannel-example/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>tchannel-core</artifactId>
             <version>0.1.3-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.uber.tchannel</groupId>
+            <artifactId>tchannel-hyperbahn</artifactId>
+            <version>0.1.3-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -27,17 +27,12 @@ import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.hyperbahn.api.HyperbahnClient;
 import com.uber.tchannel.hyperbahn.messages.AdvertiseResponse;
 
-import java.net.UnknownHostException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
 public class HyperbahnExample {
-    public static void main(String[] args) throws UnknownHostException, InterruptedException, ExecutionException,
-            TimeoutException {
+    public static void main(String[] args) throws Exception {
         TChannel tchannel = new TChannel.Builder("hyperbahn-example").build();
         HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
         Response<AdvertiseResponse> response = hyperbahn.advertise(tchannel.getServiceName(), 0);
         System.err.println(response);
-
+        hyperbahn.shutdown();
     }
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -26,18 +26,26 @@ import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.hyperbahn.api.HyperbahnClient;
 import com.uber.tchannel.hyperbahn.messages.AdvertiseResponse;
-import io.netty.channel.ChannelFuture;
+import com.uber.tchannel.ping.PingRequestHandler;
 
 import java.util.concurrent.TimeUnit;
 
 public class HyperbahnExample {
     public static void main(String[] args) throws Exception {
-        TChannel tchannel = new TChannel.Builder("hyperbahn-example").build();
-        ChannelFuture f = tchannel.listen();
-        final HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
+        TChannel tchannel = new TChannel.Builder("hyperbahn-example")
+                .register("ping", new PingRequestHandler())
+                .build();
+
+        tchannel.listen();
+
+        HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
+
         Response<AdvertiseResponse> response = hyperbahn.advertise(tchannel.getServiceName(), 0);
+
         System.err.println(response);
+
         Thread.sleep(TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES));
+
         hyperbahn.shutdown();
     }
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -26,13 +26,18 @@ import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.hyperbahn.api.HyperbahnClient;
 import com.uber.tchannel.hyperbahn.messages.AdvertiseResponse;
+import io.netty.channel.ChannelFuture;
+
+import java.util.concurrent.TimeUnit;
 
 public class HyperbahnExample {
     public static void main(String[] args) throws Exception {
         TChannel tchannel = new TChannel.Builder("hyperbahn-example").build();
-        HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
+        ChannelFuture f = tchannel.listen();
+        final HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
         Response<AdvertiseResponse> response = hyperbahn.advertise(tchannel.getServiceName(), 0);
         System.err.println(response);
+        Thread.sleep(TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES));
         hyperbahn.shutdown();
     }
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.hyperbahn;
+
+import com.uber.tchannel.api.Response;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.hyperbahn.api.HyperbahnClient;
+import com.uber.tchannel.hyperbahn.messages.AdvertiseResponse;
+
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public class HyperbahnExample {
+    public static void main(String[] args) throws UnknownHostException, InterruptedException, ExecutionException,
+            TimeoutException {
+        TChannel tchannel = new TChannel.Builder("hyperbahn-example").build();
+        HyperbahnClient hyperbahn = new HyperbahnClient(tchannel);
+        Response<AdvertiseResponse> response = hyperbahn.advertise(tchannel.getServiceName(), 0);
+        System.err.println(response);
+
+    }
+}

--- a/tchannel-example/src/main/java/com/uber/tchannel/json/JsonRequestHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/json/JsonRequestHandler.java
@@ -20,33 +20,19 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.thrift;
+package com.uber.tchannel.json;
 
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.DefaultRequestHandler;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
-import com.uber.tchannel.thrift.generated.KeyValue;
 
-import java.util.Map;
-
-public class SetValueHandlerDefault extends DefaultRequestHandler<KeyValue.setValue_args, KeyValue.setValue_result> {
-
-    private final Map<String, String> keyValueStore;
-
-    public SetValueHandlerDefault(Map<String, String> keyValueStore) {
-        this.keyValueStore = keyValueStore;
-    }
-
+public class JsonRequestHandler extends DefaultRequestHandler<RequestPojo, ResponsePojo> {
     @Override
-    public Response<KeyValue.setValue_result> handle(Request<KeyValue.setValue_args> request) {
+    public Response<ResponsePojo> handle(Request<RequestPojo> request) {
+        System.out.println(request);
 
-        String key = request.getBody().getKey();
-        String value = request.getBody().getValue();
-
-        this.keyValueStore.put(key, value);
-
-        return new Response.Builder<>(new KeyValue.setValue_result(), request.getEndpoint(), ResponseCode.OK)
+        return new Response.Builder<>(new ResponsePojo(true, "hi!"), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .setTransportHeaders(request.getTransportHeaders())
                 .build();

--- a/tchannel-example/src/main/java/com/uber/tchannel/json/JsonServer.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/json/JsonServer.java
@@ -28,7 +28,7 @@ import io.netty.channel.ChannelFuture;
 public class JsonServer {
     public static void main(String[] args) throws Exception {
         final TChannel tchannel = new TChannel.Builder("json-server")
-                .register("json-endpoint", new JsonDefaultRequestHandler())
+                .register("json-endpoint", new JsonRequestHandler())
                 .setServerPort(8888)
                 .build();
 

--- a/tchannel-example/src/main/java/com/uber/tchannel/ping/PingRequestHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/ping/PingRequestHandler.java
@@ -22,18 +22,23 @@
 
 package com.uber.tchannel.ping;
 
-import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.DefaultRequestHandler;
+import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
 
-public class PingDefaultRequestHandler extends DefaultRequestHandler<Ping, Pong> {
+public class PingRequestHandler extends DefaultRequestHandler<Ping, Pong> {
 
     @Override
     public Response<Pong> handle(Request<Ping> request) {
 
-        return new Response.Builder<>(new Pong("pong!"), request.getEndpoint(), ResponseCode.OK)
+        return new Response.Builder<>(
+                new Pong("pong!"),
+                request.getEndpoint(),
+                ResponseCode.OK
+        )
                 .setHeaders(request.getHeaders())
+                .setTransportHeaders(request.getTransportHeaders())
                 .build();
 
     }

--- a/tchannel-example/src/main/java/com/uber/tchannel/ping/PingServer.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/ping/PingServer.java
@@ -62,7 +62,7 @@ public class PingServer {
 
     public void run() throws Exception {
         TChannel tchannel = new TChannel.Builder("ping-server")
-                .register("ping", new PingDefaultRequestHandler())
+                .register("ping", new PingRequestHandler())
                 .setServerHost(InetAddress.getLoopbackAddress())
                 .setServerPort(this.port)
                 .build();

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueRequestHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/GetValueRequestHandler.java
@@ -22,8 +22,8 @@
 
 package com.uber.tchannel.thrift;
 
-import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.DefaultRequestHandler;
+import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.thrift.generated.KeyValue;
@@ -31,11 +31,11 @@ import com.uber.tchannel.thrift.generated.NotFoundError;
 
 import java.util.Map;
 
-public class GetValueHandlerDefault extends DefaultRequestHandler<KeyValue.getValue_args, KeyValue.getValue_result> {
+public class GetValueRequestHandler extends DefaultRequestHandler<KeyValue.getValue_args, KeyValue.getValue_result> {
 
     protected final Map<String, String> keyValueStore;
 
-    public GetValueHandlerDefault(Map<String, String> keyValueStore) {
+    public GetValueRequestHandler(Map<String, String> keyValueStore) {
         this.keyValueStore = keyValueStore;
     }
 

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueServer.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueServer.java
@@ -38,8 +38,8 @@ public class KeyValueServer {
         TChannel tchannel = new TChannel.Builder("keyvalue-service")
                 .setServerPort(8888)
                 .setLogLevel(LogLevel.INFO)
-                .register("KeyValue::getValue", new GetValueHandlerDefault(keyValueStore))
-                .register("KeyValue::setValue", new SetValueHandlerDefault(keyValueStore))
+                .register("KeyValue::getValue", new GetValueRequestHandler(keyValueStore))
+                .register("KeyValue::setValue", new SetValueRequestHandler(keyValueStore))
                 .build();
 
         tchannel.listen().channel().closeFuture().sync();

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueRequestHandler.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/SetValueRequestHandler.java
@@ -20,19 +20,33 @@
  * THE SOFTWARE.
  */
 
-package com.uber.tchannel.json;
+package com.uber.tchannel.thrift;
 
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.DefaultRequestHandler;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.thrift.generated.KeyValue;
 
-public class JsonDefaultRequestHandler extends DefaultRequestHandler<RequestPojo, ResponsePojo> {
+import java.util.Map;
+
+public class SetValueRequestHandler extends DefaultRequestHandler<KeyValue.setValue_args, KeyValue.setValue_result> {
+
+    private final Map<String, String> keyValueStore;
+
+    public SetValueRequestHandler(Map<String, String> keyValueStore) {
+        this.keyValueStore = keyValueStore;
+    }
+
     @Override
-    public Response<ResponsePojo> handle(Request<RequestPojo> request) {
-        System.out.println(request);
+    public Response<KeyValue.setValue_result> handle(Request<KeyValue.setValue_args> request) {
 
-        return new Response.Builder<>(new ResponsePojo(true, "hi!"), request.getEndpoint(), ResponseCode.OK)
+        String key = request.getBody().getKey();
+        String value = request.getBody().getValue();
+
+        this.keyValueStore.put(key, value);
+
+        return new Response.Builder<>(new KeyValue.setValue_result(), request.getEndpoint(), ResponseCode.OK)
                 .setHeaders(request.getHeaders())
                 .setTransportHeaders(request.getTransportHeaders())
                 .build();

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
@@ -92,6 +92,7 @@ public class HyperbahnClient {
                 HYPERBAHN_SERVICE_NAME,
                 HYPERBAHN_ADVERTISE_ENDPOINT
         )
+                .setTTL(1, TimeUnit.SECONDS)
                 .build();
 
         final InetSocketAddress router = this.routers.get(new Random().nextInt(this.routers.size()));
@@ -103,9 +104,7 @@ public class HyperbahnClient {
                 AdvertiseResponse.class
         );
 
-        Response<AdvertiseResponse> response = responseFuture.get(1000, TimeUnit.MILLISECONDS);
-
-        return response;
+        return responseFuture.get(2, TimeUnit.SECONDS);
 
     }
 

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.hyperbahn.api;
+
+import com.uber.tchannel.api.Request;
+import com.uber.tchannel.api.Response;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.hyperbahn.messages.AdvertiseRequest;
+import com.uber.tchannel.hyperbahn.messages.AdvertiseResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class HyperbahnClient {
+
+    private static final String HOSTS_FILE_PATH = "/etc/uber/hyperbahn/hosts.json";
+    private static final String HYPERBAHN_SERVICE_NAME = "hyperbahn";
+    private static final String HYPERBAHN_ADVERTISE_ENDPOINT = "ad";
+
+    private final TChannel tchannel;
+    private final List<InetSocketAddress> routers;
+    private final Logger logger = LoggerFactory.getLogger(HyperbahnClient.class);
+
+    public HyperbahnClient(TChannel tchannel) {
+        this.tchannel = tchannel;
+        this.routers = HyperbahnClient.loadRouters();
+    }
+
+    private static List<InetSocketAddress> loadRouters() {
+
+
+    }
+
+    public Response<AdvertiseResponse> advertise(
+            String service,
+            int cost
+    ) throws InterruptedException, TimeoutException, ExecutionException {
+
+        final AdvertiseRequest advertiseRequest = new AdvertiseRequest();
+        advertiseRequest.addService(service, cost);
+
+        final Request<AdvertiseRequest> request = new Request.Builder<>(
+                advertiseRequest,
+                HYPERBAHN_SERVICE_NAME,
+                HYPERBAHN_ADVERTISE_ENDPOINT
+        )
+                .build();
+
+        final InetSocketAddress router = this.
+
+                Future < Response < AdvertiseResponse >> responseFuture = this.tchannel.callJSON(
+                InetAddress.getLoopbackAddress(),
+                21300,
+                request,
+                AdvertiseResponse.class
+        );
+
+        Response<AdvertiseResponse> response = responseFuture.get(1000, TimeUnit.MILLISECONDS);
+
+        return response;
+
+    }
+
+}

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/messages/AdvertiseRequest.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/messages/AdvertiseRequest.java
@@ -41,6 +41,15 @@ public class AdvertiseRequest {
         services.add(new Service(serviceName, cost));
     }
 
+    @Override
+    public String toString() {
+        return String.format(
+                "<%s services=%s>",
+                this.getClass().getSimpleName(),
+                this.services
+        );
+    }
+
     // Inner class representing a service object in a hyperbahn message.
     public class Service {
         private final String serviceName;
@@ -49,6 +58,16 @@ public class AdvertiseRequest {
         public Service(String serviceName, int cost) {
             this.serviceName = serviceName;
             this.cost = cost;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "<%s serviceName=%s cost=%d>",
+                    this.getClass().getSimpleName(),
+                    this.serviceName,
+                    this.cost
+            );
         }
     }
 }

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/messages/AdvertiseResponse.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/messages/AdvertiseResponse.java
@@ -28,4 +28,14 @@ public class AdvertiseResponse {
     public AdvertiseResponse(int connectionCount) {
         this.connectionCount = connectionCount;
     }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "<%s connectionCount=%d>",
+                this.getClass().getSimpleName(),
+                this.connectionCount
+        );
+    }
+
 }

--- a/tchannel-hyperbahn/src/test/java/com/uber/tchannel/hyperbahn/api/HyperbahnClientTest.java
+++ b/tchannel-hyperbahn/src/test/java/com/uber/tchannel/hyperbahn/api/HyperbahnClientTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.hyperbahn.api;
+
+import com.uber.tchannel.api.TChannel;
+
+public class HyperbahnClientTest {
+
+    @org.junit.Test
+    public void testAdvertise() throws Exception {
+        TChannel tchannel = new TChannel.Builder("hyperbahn-service").build();
+
+        HyperbahnClient hyperbahnClient = new HyperbahnClient(tchannel);
+
+    }
+}


### PR DESCRIPTION
What
====
Really basic Hyperbahn Client. Not yet 100% functioning due to TChannel bug #77 

Why
====
because hyperbahn. 

Misc
====
- Actually set the TTL on an outbound, oops.
- return an empty header map if Gson returns null on parse ( that would happen if there were no headers )
- Add a basic hyperbahn example
- fix some aggressive renaming of example request handlers
- implement basic hyperbahn client

Todo
====
- Fix #77 
- Perform a heartbeat with the Hyperbahn routers so we don't get disconnected
- implement the exponential backoff strategy for connecting

cc @truncs @brandoniles @junchaowu 