### PR TITLE
Prevent NPE when clients send null JSON headers

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/JSONSerializer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/JSONSerializer.java
@@ -29,12 +29,15 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class JSONSerializer implements Serializer.SerializerInterface {
     private static final Type HEADER_TYPE = (new TypeToken<Map<String, String>>() {
 
     }).getType();
+
+    private static final Gson GSON = new Gson();
 
     @Override
     public String decodeEndpoint(ByteBuf arg1) {
@@ -47,14 +50,15 @@ public final class JSONSerializer implements Serializer.SerializerInterface {
     public Map<String, String> decodeHeaders(ByteBuf arg2) {
         String headerJSON = arg2.toString(CharsetUtil.UTF_8);
         arg2.release();
-        return new Gson().fromJson(headerJSON, HEADER_TYPE);
+        Map<String, String> headers = GSON.fromJson(headerJSON, HEADER_TYPE);
+        return (headers != null) ? headers : new HashMap<String, String>();
     }
 
     @Override
     public <T> T decodeBody(ByteBuf arg3, Class<T> bodyType) {
         String bodyJSON = arg3.toString(CharsetUtil.UTF_8);
         arg3.release();
-        return new Gson().fromJson(bodyJSON, bodyType);
+        return GSON.fromJson(bodyJSON, bodyType);
     }
 
     @Override
@@ -64,12 +68,12 @@ public final class JSONSerializer implements Serializer.SerializerInterface {
 
     @Override
     public ByteBuf encodeHeaders(Map<String, String> applicationHeaders) {
-        return Unpooled.wrappedBuffer(new Gson().toJson(applicationHeaders, HEADER_TYPE).getBytes());
+        return Unpooled.wrappedBuffer(GSON.toJson(applicationHeaders, HEADER_TYPE).getBytes());
     }
 
     @Override
     public ByteBuf encodeBody(Object body) {
-        return Unpooled.wrappedBuffer(new Gson().toJson(body).getBytes());
+        return Unpooled.wrappedBuffer(GSON.toJson(body).getBytes());
     }
 
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/schemes/JSONSerializerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/schemes/JSONSerializerTest.java
@@ -23,6 +23,10 @@
 package com.uber.tchannel.schemes;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -34,7 +38,7 @@ public class JSONSerializerTest {
 
     private Serializer.SerializerInterface serializer;
 
-    @org.junit.Before
+    @Before
     public void setUp() throws Exception {
         this.serializer = new JSONSerializer();
     }
@@ -58,11 +62,27 @@ public class JSONSerializerTest {
     }
 
     @Test
+    public void testDecodeEmptyHeaders() throws Exception {
+        Map<String, String> emptyHeaders = new HashMap<>();
+        Map<String, String> decodedHeaders = serializer.decodeHeaders(Unpooled.EMPTY_BUFFER);
+        assertEquals(emptyHeaders, decodedHeaders);
+    }
+
+    @Test
+    public void testEncodeEmptyHeaders() throws Exception {
+
+        Map<String, String> emptyHeaders = new HashMap<>();
+        ByteBuf encodedHeaders = serializer.encodeHeaders(emptyHeaders);
+        assertEquals("{}", encodedHeaders.toString(CharsetUtil.UTF_8));
+
+    }
+
+    @Test
     public void testEncodeDecodeBody() throws Exception {
 
     }
 
-    @org.junit.After
+    @After
     public void tearDown() throws Exception {
         this.serializer = null;
     }

--- a/tchannel-core/src/test/java/com/uber/tchannel/schemes/ThriftSerializerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/schemes/ThriftSerializerTest.java
@@ -69,6 +69,14 @@ public class ThriftSerializerTest {
     }
 
     @Test
+    public void testEncodeDecodeEmptyHeaders() {
+        Map<String, String> emptyHeaders = new HashMap<>();
+        ByteBuf binaryHeaders = serializer.encodeHeaders(emptyHeaders);
+        Map<String, String> decodedHeaders = serializer.decodeHeaders(binaryHeaders);
+        assertEquals(emptyHeaders, decodedHeaders);
+    }
+
+    @Test
     public void testEncodeDecodeBody() throws Exception {
 
         // Given


### PR DESCRIPTION
What
-------
Two things:
- return an empty HashMap if the TChannel-as-JSON request comes in with null headers ( as Gson will just return `null` ).
- `Gson` objects are thread safe ( not that we're using them across threads anyway ) so move the codec to a static member and just use that for 'performance'. 