### PR TITLE
Protocol v2, init handshake, init headers, etc.

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -166,7 +166,7 @@ public final class TChannel {
         InetSocketAddress localAddress = (InetSocketAddress) f.channel().localAddress();
         this.listeningPort = localAddress.getPort();
         this.listeningHost = localAddress.getHostName();
-        this.peerManager.setHostPort(this.listeningHost, this.listeningPort);
+        this.peerManager.setHostPort(String.format("%s:%d", this.listeningHost, this.listeningPort));
         return f;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -161,6 +161,10 @@ public final class TChannel {
         return this.service;
     }
 
+    public PeerManager getPeerManager() {
+        return this.peerManager;
+    }
+
     public ChannelFuture listen() throws InterruptedException {
         ChannelFuture f = this.serverBootstrap.bind(this.host, this.port).sync();
         InetSocketAddress localAddress = (InetSocketAddress) f.channel().localAddress();

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/errors/TChannelConnectionTimeout.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/errors/TChannelConnectionTimeout.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api.errors;
+
+public class TChannelConnectionTimeout extends TChannelError {
+    public TChannelConnectionTimeout() {
+        super("Connection timeout on identification", TChannelError.ERROR_INIT_TIMEOUT);
+    }
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/errors/TChannelError.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/errors/TChannelError.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api.errors;
+
+public class TChannelError extends Exception {
+    public static final String ERROR_INIT_TIMEOUT = "tchannel.connection.timeout";
+
+    public final String type;
+    public final Exception subError;
+
+    public TChannelError(String message, String type, Exception subError) {
+        super(message);
+        this.type = type;
+        this.subError = subError;
+    }
+
+    public TChannelError(String message, String type) {
+        super(message);
+        this.type = type;
+        this.subError = null;
+    }
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/ChannelRegistrar.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/ChannelRegistrar.java
@@ -26,26 +26,26 @@ import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * Simple ChannelHandlerAdapter that is responsible solely for registering new Channels with the ChannelManager
+ * Simple ChannelHandlerAdapter that is responsible solely for registering new Channels with the PeerManager
  * and de-registering Channels when the go inactive.
  */
 public class ChannelRegistrar extends ChannelHandlerAdapter {
 
-    private final ChannelManager channelManager;
+    private final PeerManager peerManager;
 
-    public ChannelRegistrar(ChannelManager channelManager) {
-        this.channelManager = channelManager;
+    public ChannelRegistrar(PeerManager peerManager) {
+        this.peerManager = peerManager;
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
-        this.channelManager.add(ctx);
+        this.peerManager.add(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         super.channelInactive(ctx);
-        this.channelManager.remove(ctx.channel());
+        this.peerManager.remove(ctx.channel());
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/Connection.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/Connection.java
@@ -30,10 +30,11 @@ import java.util.Map;
  * Connection represents a connection to a remote address
  */
 public class Connection {
-    public Channel channel;
-    public String remoteAddress = null;
     public Direction direction = Direction.NONE;
     public ConnectionState state = ConnectionState.UNCONNECTED;
+
+    private final Channel channel;
+    private String remoteAddress = null;
 
     public Connection(Channel channel, Direction direction) {
         this.channel = channel;
@@ -41,6 +42,10 @@ public class Connection {
         if (channel.isActive() && this.state == ConnectionState.UNCONNECTED) {
             this.state = ConnectionState.CONNECTED;
         }
+    }
+
+    public Channel channel() {
+        return this.channel;
     }
 
     public synchronized boolean satisfy(ConnectionState preferedState) {
@@ -80,7 +85,7 @@ public class Connection {
         return this.remoteAddress.equals("0.0.0.0:0");
     }
 
-    public static String[] sliptHostPort(String hostPort) {
+    public static String[] splitHostPort(String hostPort) {
         String[] strs = hostPort.split(":");
         if (strs.length != 2) {
             strs = new String[2];

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/Connection.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/Connection.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.channels;
+import com.uber.tchannel.messages.InitMessage;
+import io.netty.channel.Channel;
+
+import java.util.Map;
+
+/**
+ * Connection represents a connection to a remote address
+ */
+public class Connection {
+    public Channel channel;
+    public String remoteAddress = null;
+    public Direction direction = Direction.NONE;
+    public ConnectionState state = ConnectionState.UNCONNECTED;
+
+    public Connection(Channel channel, Direction direction) {
+        this.channel = channel;
+        this.direction = direction;
+        if (channel.isActive() && this.state == ConnectionState.UNCONNECTED) {
+            this.state = ConnectionState.CONNECTED;
+        }
+    }
+
+    public synchronized boolean satisfy(ConnectionState preferedState) {
+        ConnectionState connState = this.state;
+        if (connState == ConnectionState.DESTROYED) {
+            return false;
+        } else if (preferedState == null) {
+            return true;
+        } else if (connState == preferedState || connState == ConnectionState.IDENTIFIED) {
+            return true;
+        } else if (connState == ConnectionState.CONNECTED && preferedState == ConnectionState.UNCONNECTED) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public synchronized void setState(ConnectionState state) {
+        this.state = state;
+        if (state == ConnectionState.IDENTIFIED) {
+            this.notifyAll();
+        }
+    }
+
+    public synchronized void setIndentified(Map<String, String> headers) {
+        String hostPort = headers.get(InitMessage.HOST_PORT_KEY);
+        if (hostPort == null) {
+            // TODO: handle protocol error
+            hostPort = "0.0.0.0:0";
+        }
+
+        this.remoteAddress = hostPort.trim();
+        this.setState(ConnectionState.IDENTIFIED);
+    }
+
+    public synchronized boolean isEphemeral() {
+        return this.remoteAddress.equals("0.0.0.0:0");
+    }
+
+    public static String[] sliptHostPort(String hostPort) {
+        String[] strs = hostPort.split(":");
+        if (strs.length != 2) {
+            strs = new String[2];
+            strs[0] = "0.0.0.0:";
+            strs[1] = "0";
+        }
+        return strs;
+    }
+
+    public synchronized boolean waitForIdentified(long timeout) {
+        // TODO reap connections/peers on init timeout
+        try {
+            if (this.state != ConnectionState.IDENTIFIED) {
+                this.wait(timeout);
+            }
+        } catch (InterruptedException ex) {
+            // doesn't matter if we got interrupted here ...
+        }
+
+        return this.state == ConnectionState.IDENTIFIED;
+    }
+
+    public synchronized void close() throws InterruptedException {
+        channel.close().sync();
+        this.state = ConnectionState.DESTROYED;
+    }
+
+    public enum Direction {
+        NONE,
+        IN,
+        OUT
+    }
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/ConnectionState.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/ConnectionState.java
@@ -22,30 +22,38 @@
 
 package com.uber.tchannel.channels;
 
-import io.netty.channel.ChannelHandlerAdapter;
-import io.netty.channel.ChannelHandlerContext;
+public enum ConnectionState {
+    UNCONNECTED("unconnected"),
+    CONNECTED("connected"),
+    IDENTIFIED("identified"),
+    DESTROYED("destroyed");
 
-/**
- * Simple ChannelHandlerAdapter that is responsible solely for registering new Channels with the ChannelManager
- * and de-registering Channels when the go inactive.
- */
-public class ChannelRegistrar extends ChannelHandlerAdapter {
+    private final String state;
 
-    private final ChannelManager channelManager;
-
-    public ChannelRegistrar(ChannelManager channelManager) {
-        this.channelManager = channelManager;
+    ConnectionState(String state) {
+        this.state = state;
     }
 
-    @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        super.channelActive(ctx);
-        this.channelManager.add(ctx);
+    public static ConnectionState toState(String state) {
+        if (state == null) {
+            return null;
+        }
+
+        switch (state) {
+            case "unconnected":
+                return UNCONNECTED;
+            case "connected":
+                return CONNECTED;
+            case "identified":
+                return IDENTIFIED;
+            case "destroyed":
+                return DESTROYED;
+            default:
+                return null;
+        }
     }
 
-    @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        super.channelInactive(ctx);
-        this.channelManager.remove(ctx.channel());
+    public String getState() {
+        return state;
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
@@ -23,6 +23,7 @@
 package com.uber.tchannel.channels;
 
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.HashMap;
 
@@ -133,5 +134,25 @@ public class Peer {
         }
 
         this.connections.clear();
+    }
+
+    public Map<String, Integer> getStats() {
+        int in = 0;
+        int out = 0;
+        for (ChannelId id : connections.keySet()) {
+            Connection conn = connections.get(id);
+            if (conn == null) {
+                continue;
+            } else if (conn.direction == Connection.Direction.OUT) {
+                out++;
+            } else {
+                in++;
+            }
+        }
+
+        Map<String, Integer> result = new HashMap<>();
+        result.put("connections.in", in);
+        result.put("connections.out", out);
+        return result;
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.channels;
+
+import java.util.ArrayList;
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Hashtable;
+import java.util.HashMap;
+
+import com.uber.tchannel.messages.InitMessage;
+import com.uber.tchannel.messages.InitRequest;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * Peer keeps track of open channels, and provides a way to lookup Channels by their Remote Address.
+ */
+public class Peer {
+    public ArrayList<Connection> connections = new ArrayList<>();
+    public Map<ChannelId, Connection> maps = new Hashtable<>();
+    public SocketAddress remoteAddress = null;
+
+    private ChannelManager manager;
+
+    public Peer(ChannelManager manager, SocketAddress remoteAddress) {
+        this.manager = manager;
+        this.remoteAddress = remoteAddress;
+    }
+
+    public synchronized Connection add(Connection connection) {
+        if (!maps.containsKey(connection.channel.id())) {
+            maps.put(connection.channel.id(), connection);
+            connections.add(connection);
+        }
+
+        return connection;
+    }
+
+    public synchronized Connection add(Channel channel, Connection.Direction direction) {
+        Connection conn = maps.get(channel.id());
+        if (conn == null) {
+            conn = new Connection(channel, direction);
+            add(conn);
+        }
+
+        return conn;
+    }
+
+    public synchronized Connection handleActiveConnection(ChannelHandlerContext ctx, Connection.Direction direction) {
+        Channel channel = ctx.channel();
+        Connection conn;
+        conn = add(channel, direction);
+
+        if (conn.direction == Connection.Direction.OUT) {
+            // Sending out the init request
+            InitRequest initRequest = new InitRequest(0,
+                InitMessage.DEFAULT_VERSION,
+                new HashMap<String, String>() { }
+            );
+            initRequest.setHostPort(this.manager.getHostPort());
+            // TODO: figure out what to put here
+            initRequest.setProcessName("java-process");
+
+            ChannelFuture f = ctx.writeAndFlush(initRequest);
+            f.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        }
+
+        return conn;
+    }
+
+    public synchronized void remove(Connection connection) {
+        connections.remove(connection);
+        maps.remove(connection.channel.id());
+    }
+
+    public synchronized Connection remove(Channel channel) {
+        Connection conn = maps.get(channel.id());
+        if (conn != null) {
+            maps.remove(channel.id());
+            connections.remove(connections);
+        }
+
+        return conn;
+    }
+
+    public synchronized Connection connect(Bootstrap bootstrap) throws InterruptedException {
+        Connection conn = getConnection(ConnectionState.IDENTIFIED);
+        if (conn != null) {
+            return conn;
+        }
+
+        Channel channel = bootstrap.connect(remoteAddress).sync().channel();
+        return add(channel, Connection.Direction.OUT);
+    }
+
+    public synchronized Connection getConnection(ConnectionState preferedState) {
+        Connection conn = null;
+        for (int i = 0; i < connections.size(); i++) {
+            conn = connections.get(i);
+            if (conn.satisfy(preferedState)) {
+                break;
+            }
+        }
+
+        return conn;
+    }
+
+    public synchronized Connection getConnection(ChannelId channelId) {
+        return maps.get(channelId);
+    }
+
+    public synchronized void close() throws InterruptedException {
+        for (int i = 0; i < connections.size(); i++) {
+            connections.get(i).close();
+        }
+
+        this.connections.clear();
+        this.maps.clear();
+    }
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/Peer.java
@@ -38,23 +38,24 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * Peer keeps track of open channels, and provides a way to lookup Channels by their Remote Address.
+ * Peer manages connections to/from the same host_port. It provides a way to choose connections based on
+ * their current status, e.g., connected, identified, etc.
  */
 public class Peer {
     public ArrayList<Connection> connections = new ArrayList<>();
     public Map<ChannelId, Connection> maps = new Hashtable<>();
     public SocketAddress remoteAddress = null;
 
-    private ChannelManager manager;
+    private PeerManager manager;
 
-    public Peer(ChannelManager manager, SocketAddress remoteAddress) {
+    public Peer(PeerManager manager, SocketAddress remoteAddress) {
         this.manager = manager;
         this.remoteAddress = remoteAddress;
     }
 
     public synchronized Connection add(Connection connection) {
-        if (!maps.containsKey(connection.channel.id())) {
-            maps.put(connection.channel.id(), connection);
+        if (!maps.containsKey(connection.channel().id())) {
+            maps.put(connection.channel().id(), connection);
             connections.add(connection);
         }
 
@@ -95,7 +96,7 @@ public class Peer {
 
     public synchronized void remove(Connection connection) {
         connections.remove(connection);
-        maps.remove(connection.channel.id());
+        maps.remove(connection.channel().id());
     }
 
     public synchronized Connection remove(Channel channel) {

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/PeerManager.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/PeerManager.java
@@ -32,13 +32,9 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * ChannelManager keeps track of open channels, and provides a way to lookup Channels by their Remote Address.
- * <p>
- * ChannelManager} maintains both a ChannelGroup of open connections and a Map of InetSocketAddress to ChannelId so that
- * connections can be reused if a request is going to the same remote. The ChannelManager also provides a convenient
- * entry point for shutting down all active Channels.
+ * PeerManager manages peers, a abstract presentation of a channel to a host_port.
  */
-public class ChannelManager {
+public class PeerManager {
     private final Map<SocketAddress, Peer> peers = new Hashtable<>();
     private String host = "0.0.0.0";
     private int port = 0;
@@ -80,15 +76,14 @@ public class ChannelManager {
             }
         }
 
-        return peer.handleActiveConnection(ctx, getDirection(ctx)).channel;
-    }
-
-    public static Connection.Direction getDirection(ChannelHandlerContext ctx) {
+        // Direction only matters for the init path when the
+        // init handler hasn't been removed
+        Connection.Direction direction = Connection.Direction.OUT;
         if (ctx.pipeline().names().contains("InitRequestHandler")) {
-            return Connection.Direction.IN;
-        } else {
-            return Connection.Direction.OUT;
+            direction = Connection.Direction.IN;
         }
+
+        return peer.handleActiveConnection(ctx, direction).channel();
     }
 
     public void remove(Channel channel) throws InterruptedException {

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/PeerManager.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/PeerManager.java
@@ -27,6 +27,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.net.SocketAddress;
+import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
@@ -119,5 +120,20 @@ public class PeerManager {
 
     public String getHostPort() {
         return this.hostPort;
+    }
+
+    public Map<String, Integer> getStats() {
+        int in = 0;
+        int out = 0;
+        for (SocketAddress addr : peers.keySet()) {
+            Map<String, Integer> connStats = peers.get(addr).getStats();
+            in += connStats.get("connections.in");
+            out += connStats.get("connections.out");
+        }
+
+        Map<String, Integer> result = new HashMap<>();
+        result.put("connections.in", in);
+        result.put("connections.out", out);
+        return result;
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
@@ -21,7 +21,7 @@
  */
 package com.uber.tchannel.handlers;
 
-import com.uber.tchannel.channels.ChannelManager;
+import com.uber.tchannel.channels.PeerManager;
 import com.uber.tchannel.errors.FatalProtocolError;
 import com.uber.tchannel.errors.ProtocolError;
 import com.uber.tchannel.errors.ProtocolErrorProcessor;
@@ -37,10 +37,10 @@ import io.netty.channel.SimpleChannelInboundHandler;
 
 public class InitRequestHandler extends SimpleChannelInboundHandler<Message> {
 
-    private final ChannelManager channelManager;
+    private final PeerManager peerManager;
 
-    public InitRequestHandler(ChannelManager channelManager) {
-        this.channelManager = channelManager;
+    public InitRequestHandler(PeerManager peerManager) {
+        this.peerManager = peerManager;
     }
 
     @Override
@@ -57,13 +57,13 @@ public class InitRequestHandler extends SimpleChannelInboundHandler<Message> {
                             initRequestMessage.getId(),
                             InitMessage.DEFAULT_VERSION
                     );
-                    initResponse.setHostPort(this.channelManager.getHostPort());
+                    initResponse.setHostPort(this.peerManager.getHostPort());
                     // TODO: figure out what to put here
                     initResponse.setProcessName("java-process");
                     ChannelFuture f = ctx.writeAndFlush(initResponse);
                     f.addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
                     ctx.pipeline().remove(this);
-                    channelManager.setIdentified(ctx.channel(), initRequestMessage.getHeaders());
+                    peerManager.setIdentified(ctx.channel(), initRequestMessage.getHeaders());
                 } else {
                     // TODO: response ProtocolError
                     throw new FatalProtocolError(
@@ -76,7 +76,7 @@ public class InitRequestHandler extends SimpleChannelInboundHandler<Message> {
 
             default:
 
-                // TODO: should send back BadRequest
+                // TODO: should send back ProtocolError
                 throw new FatalProtocolError(
                         "Must not send any data until receiving Init Request",
                         new Trace(0, 0, 0, (byte) 0x00)

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestInitiator.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestInitiator.java
@@ -22,7 +22,7 @@
 
 package com.uber.tchannel.handlers;
 
-import com.uber.tchannel.channels.ChannelManager;
+import com.uber.tchannel.channels.PeerManager;
 import com.uber.tchannel.errors.FatalProtocolError;
 import com.uber.tchannel.errors.ProtocolError;
 import com.uber.tchannel.errors.ProtocolErrorProcessor;
@@ -35,10 +35,10 @@ import io.netty.channel.SimpleChannelInboundHandler;
 
 public class InitRequestInitiator extends SimpleChannelInboundHandler<Message> {
 
-    private final ChannelManager channelManager;
+    private final PeerManager peerManager;
 
-    public InitRequestInitiator(ChannelManager channelManager) {
-        this.channelManager = channelManager;
+    public InitRequestInitiator(PeerManager peerManager) {
+        this.peerManager = peerManager;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class InitRequestInitiator extends SimpleChannelInboundHandler<Message> {
 
                 if (initResponseMessage.getVersion() == InitMessage.DEFAULT_VERSION) {
                     ctx.pipeline().remove(this);
-                    channelManager.setIdentified(ctx.channel(), initResponseMessage.getHeaders());
+                    peerManager.setIdentified(ctx.channel(), initResponseMessage.getHeaders());
                 } else {
                     throw new FatalProtocolError(
                             String.format("Expected Protocol version: %d", InitMessage.DEFAULT_VERSION),

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
@@ -59,6 +59,5 @@ public class ResponseRouter extends SimpleChannelInboundHandler<RawResponse> {
     protected void messageReceived(ChannelHandlerContext ctx, RawResponse rawResponse) throws Exception {
         SettableFuture<RawResponse> future = this.messageMap.remove(rawResponse.getId());
         future.set(rawResponse);
-
     }
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/InitRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/InitRequest.java
@@ -60,8 +60,16 @@ public final class InitRequest implements Message, InitMessage {
         return this.headers.get(HOST_PORT_KEY);
     }
 
+    public void setHostPort(String hostPort) {
+        this.headers.put(HOST_PORT_KEY, hostPort);
+    }
+
     public String getProcessName() {
         return this.headers.get(PROCESS_NAME_KEY);
+    }
+
+    public void setProcessName(String processName) {
+        this.headers.put(PROCESS_NAME_KEY, processName);
     }
 
     @Override

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/InitResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/InitResponse.java
@@ -21,6 +21,7 @@
  */
 package com.uber.tchannel.messages;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -33,6 +34,12 @@ public final class InitResponse implements InitMessage, Message {
     private final long id;
     private final int version;
     private final Map<String, String> headers;
+
+    public InitResponse(long id, int version) {
+        this.id = id;
+        this.version = version;
+        this.headers = new HashMap<>();
+    }
 
     public InitResponse(long id, int version, Map<String, String> headers) {
         this.id = id;
@@ -60,8 +67,14 @@ public final class InitResponse implements InitMessage, Message {
         return this.headers.get(HOST_PORT_KEY);
     }
 
+    public void setHostPort(String hostPort) { this.headers.put(HOST_PORT_KEY, hostPort); }
+
     public String getProcessName() {
         return this.headers.get(PROCESS_NAME_KEY);
+    }
+
+    public void setProcessName(String processName) {
+        this.headers.put(PROCESS_NAME_KEY, processName);
     }
 
     @Override

--- a/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/schemes/RawRequest.java
@@ -23,6 +23,7 @@
 package com.uber.tchannel.schemes;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 
 import java.util.HashMap;
@@ -70,6 +71,14 @@ public final class RawRequest implements RawMessage {
         this.arg1 = arg1;
         this.arg2 = arg2;
         this.arg3 = arg3;
+    }
+
+    public RawRequest(long ttl, String service, Map<String, String> transportHeaders,
+                      String arg1, String arg2, String arg3) {
+        this(ttl, service, transportHeaders,
+                Unpooled.wrappedBuffer(arg1.getBytes()),
+                Unpooled.wrappedBuffer(arg2.getBytes()),
+                Unpooled.wrappedBuffer(arg3.getBytes()));
     }
 
     @Override

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/PeerManagerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/PeerManagerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.tchannel.api.handlers.JSONRequestHandler;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.logging.LogLevel;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.handlers.RequestHandler;
+import com.uber.tchannel.schemes.RawRequest;
+import com.uber.tchannel.schemes.RawResponse;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.uber.tchannel.api.handlers.RequestHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PeerManagerTest {
+
+    @Test
+    public void testPeerAndConnections() throws Exception {
+
+        InetAddress host = InetAddress.getByName("127.0.0.1");
+
+        // create server
+        final TChannel server = new TChannel.Builder("server")
+                .register("echo", new EchoHandler())
+                .setServerHost(host)
+                .build();
+        server.listen();
+
+        int port = server.getListeningPort();
+
+        // create client
+        final TChannel client = new TChannel.Builder("json-server")
+                .setServerHost(host)
+                .build();
+        client.listen();
+
+        RawRequest req = new RawRequest(
+                1000,
+                "server",
+                null,
+                "echo",
+                "title",
+                "hello"
+        );
+
+        ListenableFuture<RawResponse> future = client.call(
+                host,
+                port,
+                req
+        );
+
+        RawResponse res = future.get(100, TimeUnit.MILLISECONDS);
+        assertEquals(res.getArg1().toString(CharsetUtil.UTF_8), "echo");
+        assertEquals(res.getArg2().toString(CharsetUtil.UTF_8), "title");
+        assertEquals(res.getArg3().toString(CharsetUtil.UTF_8), "hello");
+
+        // checking the connections
+        Map<String, Integer> stats = client.getPeerManager().getStats();
+        assertEquals((int)stats.get("connections.in"), 0);
+        assertEquals((int)stats.get("connections.out"), 1);
+
+        stats = server.getPeerManager().getStats();
+        assertEquals((int)stats.get("connections.in"), 1);
+        assertEquals((int)stats.get("connections.out"), 0);
+
+        client.shutdown();
+        server.shutdown();
+
+        stats = client.getPeerManager().getStats();
+        assertEquals((int)stats.get("connections.in"), 0);
+        assertEquals((int)stats.get("connections.out"), 0);
+
+        stats = server.getPeerManager().getStats();
+        assertEquals((int)stats.get("connections.in"), 0);
+        assertEquals((int)stats.get("connections.out"), 0);
+
+    }
+
+    protected  class EchoHandler implements RequestHandler {
+        @Override
+        public RawResponse handle(RawRequest request) {
+            RawResponse response = new RawResponse(
+                    request.getId(),
+                    ResponseCode.OK,
+                    request.getTransportHeaders(),
+                    request.getArg1(),
+                    request.getArg2(),
+                    request.getArg3()
+            );
+
+            return response;
+        }
+    }
+}
+
+

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitDefaultRequestHandlerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitDefaultRequestHandlerTest.java
@@ -22,7 +22,7 @@
 package com.uber.tchannel.handlers;
 
 import com.uber.tchannel.Fixtures;
-import com.uber.tchannel.channels.ChannelManager;
+import com.uber.tchannel.channels.PeerManager;
 import com.uber.tchannel.errors.ErrorType;
 import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.ErrorMessage;
@@ -52,7 +52,7 @@ public class InitDefaultRequestHandlerTest {
 
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler(new ChannelManager())
+                new InitRequestHandler(new PeerManager())
         );
 
         assertEquals(3, channel.pipeline().names().size());
@@ -96,7 +96,7 @@ public class InitDefaultRequestHandlerTest {
 
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler(new ChannelManager())
+                new InitRequestHandler(new PeerManager())
         );
 
         InitRequest initRequest = new InitRequest(42,
@@ -125,7 +125,7 @@ public class InitDefaultRequestHandlerTest {
     public void testInvalidCallBeforeInitRequest() throws Exception {
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler(new ChannelManager())
+                new InitRequestHandler(new PeerManager())
         );
 
         CallRequest callRequest = Fixtures.callRequest(0, false, Unpooled.EMPTY_BUFFER);
@@ -143,7 +143,7 @@ public class InitDefaultRequestHandlerTest {
     public void testIncorrectProtocolVersion() throws Exception {
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler(new ChannelManager())
+                new InitRequestHandler(new PeerManager())
         );
 
         InitRequest initRequest = new InitRequest(42,

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitDefaultRequestHandlerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitDefaultRequestHandlerTest.java
@@ -22,6 +22,7 @@
 package com.uber.tchannel.handlers;
 
 import com.uber.tchannel.Fixtures;
+import com.uber.tchannel.channels.ChannelManager;
 import com.uber.tchannel.errors.ErrorType;
 import com.uber.tchannel.messages.CallRequest;
 import com.uber.tchannel.messages.ErrorMessage;
@@ -51,7 +52,7 @@ public class InitDefaultRequestHandlerTest {
 
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler()
+                new InitRequestHandler(new ChannelManager())
         );
 
         assertEquals(3, channel.pipeline().names().size());
@@ -95,7 +96,7 @@ public class InitDefaultRequestHandlerTest {
 
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler()
+                new InitRequestHandler(new ChannelManager())
         );
 
         InitRequest initRequest = new InitRequest(42,
@@ -124,7 +125,7 @@ public class InitDefaultRequestHandlerTest {
     public void testInvalidCallBeforeInitRequest() throws Exception {
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler()
+                new InitRequestHandler(new ChannelManager())
         );
 
         CallRequest callRequest = Fixtures.callRequest(0, false, Unpooled.EMPTY_BUFFER);
@@ -142,7 +143,7 @@ public class InitDefaultRequestHandlerTest {
     public void testIncorrectProtocolVersion() throws Exception {
         // Given
         EmbeddedChannel channel = new EmbeddedChannel(
-                new InitRequestHandler()
+                new InitRequestHandler(new ChannelManager())
         );
 
         InitRequest initRequest = new InitRequest(42,

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
@@ -22,14 +22,12 @@
 
 package com.uber.tchannel.handlers;
 
-import com.uber.tchannel.channels.ChannelManager;
+import com.uber.tchannel.channels.PeerManager;
 import com.uber.tchannel.channels.ChannelRegistrar;
 import com.uber.tchannel.messages.InitRequest;
 import com.uber.tchannel.messages.InitResponse;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Test;
-
-import javax.sound.midi.SysexMessage;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
@@ -40,7 +38,7 @@ public class InitRequestInitiatorTest {
     @Test
     public void testValidInitResponse() throws Exception {
         // Given
-        ChannelManager manager = new ChannelManager();
+        PeerManager manager = new PeerManager();
         manager.setHostPort("127.0.0.1", 8888);
         EmbeddedChannel channel = new EmbeddedChannel(
                 new ChannelRegistrar(manager)

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
@@ -53,7 +53,8 @@ public class InitRequestInitiatorTest {
         // Assert
         assertNotNull(initRequest);
         // Headers as expected
-        assertEquals(initRequest.getHeaders().toString(), "{host_port=127.0.0.1:8888, process_name=java-process}");
+        assertEquals(initRequest.getHeaders().get("host_port"), "127.0.0.1:8888");
+        assertEquals(initRequest.getHeaders().get("process_name"), "java-process");
 
         channel.writeInbound(new InitResponse(
                 initRequest.getId(),

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/InitRequestInitiatorTest.java
@@ -39,7 +39,7 @@ public class InitRequestInitiatorTest {
     public void testValidInitResponse() throws Exception {
         // Given
         PeerManager manager = new PeerManager();
-        manager.setHostPort("127.0.0.1", 8888);
+        manager.setHostPort(String.format("%s:%d", "127.0.0.1", 8888));
         EmbeddedChannel channel = new EmbeddedChannel(
                 new ChannelRegistrar(manager)
         );

--- a/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/thrift/KeyValueClient.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.uber.tchannel.api.Request;
 import com.uber.tchannel.api.Response;
 import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.errors.TChannelError;
 import com.uber.tchannel.thrift.generated.KeyValue;
 import com.uber.tchannel.thrift.generated.NotFoundError;
 
@@ -76,7 +77,8 @@ public class KeyValueClient {
     public static String getValue(
             TChannel tchannel,
             String key
-    ) throws NotFoundError, UnknownHostException, TimeoutException, ExecutionException, InterruptedException {
+    ) throws NotFoundError, UnknownHostException, TimeoutException,
+            ExecutionException, InterruptedException, TChannelError {
 
         KeyValue.getValue_args getValue = new KeyValue.getValue_args(key);
 


### PR DESCRIPTION
Efforts to make tchannel-java talking to other languages & Hyperbahn:
1. Init req/res handshake should finish before other req/res can start: tchannel v2 protocol
2. Init req/res should have the host_port set when listen. It should use "0.0.0.0:0" otherwise for ephemeral ports.
3. Connection pool and peer selection support, e.g., should be able to prefer Hyperbahn affinity connections. 

r: @willsalz @truncs @anson627 

I feel this is enough for the first step to unblock Hyperbahn client & talking to other languages. The are still many places to improve. E.g., the connection pool can be a bottleneck for multi-threading. It can be relieved by read-write locks. But all for next steps.