### PR TITLE
use ip address instead of hostname to initialize TChannel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 sudo: required
 language: java
-addons:
-  apt:
-    packages:
-    - thrift-compiler
 before_install:
     - bash build/travis/install-thrift.sh

--- a/pom.xml
+++ b/pom.xml
@@ -121,26 +121,12 @@
 
     <profiles>
         <profile>
-            <id>uber</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.3</version>
-                        <configuration>
-                            <useReleaseProfile>false</useReleaseProfile>
-                            <releaseProfiles>release</releaseProfiles>
-                            <goals>deploy</goals>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>ossrh</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>build</name>
+                    <value>release</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -96,6 +96,10 @@ public final class TChannel {
         this.clientMaxPendingRequests = builder.clientMaxPendingRequests;
     }
 
+    public String getListeningHost() {
+        return listeningHost;
+    }
+
     public int getListeningPort() {
         return listeningPort;
     }

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -136,7 +136,7 @@ public final class TChannel {
         ChannelFuture f = this.serverBootstrap.bind(this.host, this.port).sync();
         InetSocketAddress localAddress = (InetSocketAddress) f.channel().localAddress();
         this.listeningPort = localAddress.getPort();
-        this.listeningHost = localAddress.getHostName();
+        this.listeningHost = localAddress.getAddress().getHostAddress();
         this.peerManager.setHostPort(String.format("%s:%d", this.listeningHost, this.listeningPort));
         return f;
     }

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
@@ -47,11 +47,15 @@ public class TChannelBuilderTest extends BaseTest {
     @Test
     public void testServerListeningHostValidity() throws Exception {
 
+        // InetAddress constructed using hostname will not return IP address
+        // with getHostName call
         TChannel tchannel = new TChannel.Builder("some-service")
                 .setServerHost(InetAddress.getByName("localhost"))
                 .build();
         tchannel.listen();
-        System.out.println(tchannel.getListeningHost());
+
+        // The regular expression used here doesn't cover all invalid cases, but it's
+        // consistent with the one in javascript code
         assertTrue((tchannel.getListeningHost().matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$")));
     }
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.net.InetAddress;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TChannelBuilderTest extends BaseTest {
 
@@ -41,6 +42,17 @@ public class TChannelBuilderTest extends BaseTest {
         assertEquals("localhost", tchannel.getHost().getCanonicalHostName());
         tchannel.shutdown();
 
+    }
+
+    @Test
+    public void testServerListeningHostValidity() throws Exception {
+
+        TChannel tchannel = new TChannel.Builder("some-service")
+                .setServerHost(InetAddress.getByName("localhost"))
+                .build();
+        tchannel.listen();
+        System.out.println(tchannel.getListeningHost());
+        assertTrue((tchannel.getListeningHost().matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$")));
     }
 
 }


### PR DESCRIPTION
hyperbahn requires that the client registers with a valid IP address.