### PR TITLE
CodecTestUtil is not a junit test.

### DIFF
--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CodecTestUtil.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CodecTestUtil.java
@@ -22,15 +22,11 @@
 
 package com.uber.tchannel.codecs;
 
-import com.uber.tchannel.BaseTest;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 
-public class CodecTestUtil extends BaseTest {
+public class CodecTestUtil {
 
-    @Test
     public static TFrame encodeDecode(TFrame frame) {
         EmbeddedChannel channel = new EmbeddedChannel(
                 new TChannelLengthFieldBasedFrameDecoder(),


### PR DESCRIPTION
Looks like it doesn't cause any errors when running the tests from mvn. My Intellij config tried to run the class as a test though and throws an error.