### PR TITLE
Downgrade to work with netty 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>5.0.0.Alpha2</version>
+            <version>4.1.0.CR3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tchannel-core/src/main/java/com/uber/tchannel/channels/ChannelRegistrar.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/channels/ChannelRegistrar.java
@@ -22,8 +22,8 @@
 
 package com.uber.tchannel.channels;
 
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * Simple ChannelHandlerAdapter that is responsible solely for registering new Channels with the PeerManager
  * and de-registering Channels when the go inactive.
  */
-public class ChannelRegistrar extends ChannelHandlerAdapter {
+public class ChannelRegistrar extends ChannelInboundHandlerAdapter {
 
     private static final Logger logger = LoggerFactory.getLogger(ChannelRegistrar.class);
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestHandler.java
@@ -44,7 +44,7 @@ public class InitRequestHandler extends SimpleChannelInboundHandler<ByteBuf> {
     }
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
+    public void channelRead0(ChannelHandlerContext ctx, ByteBuf buf) throws Exception {
 
         Frame frame = MessageCodec.decode(
             MessageCodec.decode(buf)

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestInitiator.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/InitRequestInitiator.java
@@ -43,7 +43,7 @@ public class InitRequestInitiator extends SimpleChannelInboundHandler<ByteBuf> {
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, ByteBuf buf) throws TChannelError {
+    protected void channelRead0(ChannelHandlerContext ctx, ByteBuf buf) throws TChannelError {
 
         Frame frame = MessageCodec.decode(
             MessageCodec.decode(buf)

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/PingHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/PingHandler.java
@@ -30,7 +30,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 public class PingHandler extends SimpleChannelInboundHandler<PingRequestFrame> {
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, PingRequestFrame msg) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, PingRequestFrame msg) throws Exception {
         ctx.writeAndFlush(MessageCodec.encode(ctx.alloc(), new PingResponseFrame(msg.getId())));
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
@@ -78,7 +78,7 @@ public class RequestRouter extends SimpleChannelInboundHandler<Request> {
     }
 
     @Override
-    protected void messageReceived(final ChannelHandlerContext ctx, final Request request) {
+    protected void channelRead0(final ChannelHandlerContext ctx, final Request request) {
 
         // There is nothing to do if the connection is already distroyed.
         if (!ctx.channel().isActive()) {

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/ResponseRouter.java
@@ -186,7 +186,7 @@ public class ResponseRouter extends SimpleChannelInboundHandler<ResponseMessage>
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, ResponseMessage response) {
+    protected void channelRead0(ChannelHandlerContext ctx, ResponseMessage response) {
         handleResponse(response);
     }
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/ErrorCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/ErrorCodecTest.java
@@ -44,9 +44,11 @@ public class ErrorCodecTest extends BaseTest {
         );
 
         TFrame tFrame = MessageCodec.encode(ByteBufAllocator.DEFAULT, errorFrame);
+        tFrame = CodecTestUtil.encodeDecode(tFrame);
+
         ErrorFrame newErrorFrame =
             (ErrorFrame) MessageCodec.decode(
-                CodecTestUtil.encodeDecode(tFrame)
+                tFrame
             );
 
         assertEquals(errorFrame.getId(), newErrorFrame.getId());


### PR DESCRIPTION
Resolves #127 

Did some basic testing. Not sure how much apps depending on this are using netty 5.0 though.

Looks like there was some changes to the embedded pipelining buffers which caused a leak in the ErrorCodecTest. Other than that I there weren't any function changes needed.