### PR TITLE
fix spelling of registerHealthHandler method

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
@@ -100,7 +100,12 @@ public final class SubChannel {
         return this;
     }
 
+    @Deprecated
     public SubChannel registerHealthHanlder() {
+        return registerHealthHandler();
+    }
+
+    public SubChannel registerHealthHandler() {
         return registerHealthHandler(new HealthCheckRequestHandler());
     }
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/channels/HealthCheckTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/channels/HealthCheckTest.java
@@ -48,7 +48,7 @@ public class HealthCheckTest extends BaseTest {
                 .setServerHost(host)
                 .build();
         final SubChannel subServer = server.makeSubChannel("server");
-        subServer.registerHealthHanlder();
+        subServer.registerHealthHandler();
         server.listen();
 
         int port = server.getListeningPort();

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -64,7 +64,7 @@ public class HyperbahnExample {
 
         // register the service handler
         hyperbahn.makeClientChannel("javaServer")
-            .registerHealthHanlder()
+            .registerHealthHandler()
             .register("ping", new PingRequestHandler());
 
         final TFuture<JsonResponse<AdvertiseResponse>> future = hyperbahn.advertise();


### PR DESCRIPTION
Deprecate SubChannel.registerHealthHanlder() to be removed later
Fixes #120