### PR TITLE
Borrow the getCurrentIp implementation from Go

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/utils/TChannelUtilities.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/utils/TChannelUtilities.java
@@ -54,7 +54,7 @@ public class TChannelUtilities {
                 }
             }
         } catch (SocketException e) {
-            logger.error("unable to score IP.", e);
+            logger.error("Unable to score IP {} of interface {}", addr, iface, e);
         }
 
         return score;
@@ -87,7 +87,7 @@ public class TChannelUtilities {
                 }
             }
         } catch (IOException e) {
-            logger.error("problem getting local IP.", e);
+            logger.error("Problem getting local IP", e);
         }
 
         return bestAddr;

--- a/tchannel-core/src/main/java/com/uber/tchannel/utils/TChannelUtilities.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/utils/TChannelUtilities.java
@@ -54,7 +54,7 @@ public class TChannelUtilities {
                 }
             }
         } catch (SocketException e) {
-            ;
+            logger.error("unable to score IP.", e);
         }
 
         return score;
@@ -87,7 +87,7 @@ public class TChannelUtilities {
                 }
             }
         } catch (IOException e) {
-            ;
+            logger.error("problem getting local IP.", e);
         }
 
         return bestAddr;


### PR DESCRIPTION
Resolves #137.

Java's iteration order for network interfaces looks reversed from Go. Here's Go's [`ListenIP`](https://github.com/uber/tchannel-go/blob/dev/localip.go#L59) with some logging added:
```
$ go run main.go
2016/07/23 17:15:02 Checking 127.0.0.1/8
2016/07/23 17:15:02 Checking 10.28.174.63/32
2016/07/23 17:15:02 Checking ::1/128
2016/07/23 17:15:02 Checking 10.28.40.63/24
2016/07/23 17:15:02 Checking fe80::2e60:cff:fea2:2f30/64
2016/07/23 17:15:02 Checking 10.28.104.63/24
2016/07/23 17:15:02 Checking fe80::2e60:cff:fea2:2f31/64
2016/07/23 17:15:02 Checking 172.17.0.1/16
```

And here's Java:
```
$ java IpTest
Checking 172.17.0.1
Checking fe80:0:0:0:2e60:cff:fea2:2f31%3
Checking 10.28.104.63
Checking fe80:0:0:0:2e60:cff:fea2:2f30%2
Checking 10.28.40.63
Checking 0:0:0:0:0:0:0:1%1
Checking 10.28.174.63
Checking 127.0.0.1
```

This PR mimics the Go implementation but prefers the last-seen match instead of the first-seen to account for this reverse ordering. The existing Java implementation had some other differences from Go (wasn't checking if the interface was up, for example) and so I feel more comfortable just copying Go since we know that works well.

I've confirmed locally that with this change Java will listen on the same IP as Go.