### PR TITLE
ThriftAsyncFutureHandler and AsyncRequestHandler

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/AsyncRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/AsyncRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Uber Technologies, Inc.
+ * Copyright (c) 2016 Uber Technologies, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,17 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.uber.tchannel.messages.Request;
 import com.uber.tchannel.messages.Response;
 
+/**
+ * Allows requests to be handle asynchronously by letting the actual handler return a future.
+ */
 public interface AsyncRequestHandler extends RequestHandler {
+
+    /**
+     * Main handle method for the AsyncRequestHandler that returns a ListenableFuture. This method
+     * should not make any blocking calls so that the calling thread is reliquished quickly.
+     *
+     * @param request Request to handle
+     * @return A ListenableFuture representing the result of the request handling.
+     */
     ListenableFuture<? extends Response> handleAsync(Request request);
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/AsyncRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/AsyncRequestHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api.handlers;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.tchannel.messages.Request;
+import com.uber.tchannel.messages.Response;
+
+public interface AsyncRequestHandler extends RequestHandler {
+    ListenableFuture<? extends Response> handleAsync(Request request);
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
@@ -22,6 +22,7 @@
 
 package com.uber.tchannel.api.handlers;
 
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.uber.tchannel.messages.Request;
 import com.uber.tchannel.messages.Response;
@@ -40,8 +41,8 @@ public abstract class ThriftAsyncRequestHandler<T, U> implements AsyncRequestHan
         try {
             return this.handleAsync(request).get();
         } catch (InterruptedException | ExecutionException ex) {
-            // Cannot do much better with this exception so re-raising a RuntimeException.
-            throw new RuntimeException(ex);
+            // Cannot do much better with this exception so propogate the exception.
+            throw Throwables.propagate(ex);
         }
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.uber.tchannel.api.handlers;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.tchannel.messages.Request;
+import com.uber.tchannel.messages.Response;
+import com.uber.tchannel.messages.ThriftRequest;
+import com.uber.tchannel.messages.ThriftResponse;
+
+import java.util.concurrent.ExecutionException;
+
+public abstract class ThriftAsyncRequestHandler<T, U> implements AsyncRequestHandler {
+    @Override
+    public Response handle(Request request) {
+        try {
+            return this.handleAsync(request).get();
+        } catch (InterruptedException | ExecutionException ex) {
+            // Cannot do much better with this exception so re-raising a RuntimeException.
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public ListenableFuture<? extends Response> handleAsync(Request request) {
+        return handleImpl((ThriftRequest<T>)request);
+    }
+
+    public abstract ListenableFuture<ThriftResponse<U>> handleImpl(ThriftRequest<T> request);
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/handlers/ThriftAsyncRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Uber Technologies, Inc.
+ * Copyright (c) 2016 Uber Technologies, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,10 @@ import com.uber.tchannel.messages.ThriftResponse;
 
 import java.util.concurrent.ExecutionException;
 
+/**
+ * Specialized async handler for thrift calls. Like the AsyncRequestHandler it also allows requests
+ * to be handle asynchronously by letting the actual handler return a future.
+ */
 public abstract class ThriftAsyncRequestHandler<T, U> implements AsyncRequestHandler {
     @Override
     public Response handle(Request request) {
@@ -47,5 +51,13 @@ public abstract class ThriftAsyncRequestHandler<T, U> implements AsyncRequestHan
         return handleImpl((ThriftRequest<T>)request);
     }
 
+    /**
+     * Main handle method for ThriftAsyncRequestHandler that return a ListenableFuture scoped down
+     * to ThriftResponse.  This method should not make any blocking calls so that the calling thread
+     * is reliquished quickly.
+     *
+     * @param request ThriftRequest to handle
+     * @return A ListenableFuture representing the result of thrift request handling.
+     */
     public abstract ListenableFuture<ThriftResponse<U>> handleImpl(ThriftRequest<T> request);
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.tchannel.handlers;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.tchannel.BaseTest;
+import com.uber.tchannel.api.handlers.ThriftAsyncRequestHandler;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.TFuture;
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.messages.ThriftRequest;
+import com.uber.tchannel.messages.ThriftResponse;
+import com.uber.tchannel.messages.generated.Example;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class TestThriftAsyncRequestHandler extends BaseTest {
+
+    @Test
+    public void fullRequestResponse() throws Exception {
+        final Example requestBody = new Example("Hello, World!", 10);
+        final Example responseBody = new Example("Bonjour le monde!", 20);
+
+        TChannel tchannel = new TChannel.Builder("tchannel-name")
+            .setServerHost(InetAddress.getByName("127.0.0.1"))
+            .build();
+        SubChannel subChannel = tchannel.makeSubChannel("tchannel-name")
+            .register("endpoint", new ThriftAsyncRequestHandler<Example, Example>() {
+                public ListenableFuture<ThriftResponse<Example>> handleImpl(ThriftRequest<Example> request) {
+                    assertEquals(requestBody, request.getBody(Example.class));
+                    return Futures.immediateFuture(new ThriftResponse.Builder<Example>(request)
+                        .setTransportHeaders(request.getTransportHeaders())
+                        .setBody(responseBody)
+                        .build());
+                }
+        });
+
+        tchannel.listen();
+
+        ThriftResponse<Example> response = null;
+        try {
+            ThriftRequest<Example> request = new ThriftRequest.Builder<Example>("tchannel-name", "endpoint")
+                .setTimeout(2000000)
+                .setBody(requestBody)
+                .build();
+
+            TFuture<ThriftResponse<Example>> responsePromise = subChannel.send(
+                request,
+                tchannel.getHost(),
+                tchannel.getListeningPort()
+            );
+
+            response = responsePromise.get();
+            assertNull(response.getError());
+            assertEquals(responseBody, (Example) response.getBody(Example.class));
+        } finally {
+            if (response != null) {
+                response.release();
+            }
+            tchannel.shutdown();
+        }
+    }
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
@@ -48,18 +48,6 @@ import static org.junit.Assert.assertNull;
 
 public class TestThriftAsyncRequestHandler extends BaseTest {
 
-    private static Tracer tracer;
-    private static InMemoryReporter reporter;
-    private static TracingContext tracingContext;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        reporter = new InMemoryReporter();
-        Sampler sampler = new ConstSampler(true);
-        tracer = new Tracer.Builder("tchannel-name", reporter, sampler).build();
-        tracingContext = new TracingContext.ThreadLocal();
-    }
-
     @Test
     public void fullRequestResponse() throws Exception {
         final Example requestBody = new Example("Hello, World!", 10);
@@ -67,8 +55,7 @@ public class TestThriftAsyncRequestHandler extends BaseTest {
 
         TChannel tchannel = new TChannel.Builder("tchannel-name")
             .setServerHost(InetAddress.getByName("127.0.0.1"))
-            .setTracer(tracer)
-            .setTracingContext(tracingContext)
+            .setTracingContext(new TracingContext.ThreadLocal())
             .build();
         SubChannel subChannel = tchannel.makeSubChannel("tchannel-name")
             .register("endpoint", new ThriftAsyncRequestHandler<Example, Example>() {

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/TestThriftAsyncRequestHandler.java
@@ -55,7 +55,6 @@ public class TestThriftAsyncRequestHandler extends BaseTest {
 
         TChannel tchannel = new TChannel.Builder("tchannel-name")
             .setServerHost(InetAddress.getByName("127.0.0.1"))
-            .setTracingContext(new TracingContext.ThreadLocal())
             .build();
         SubChannel subChannel = tchannel.makeSubChannel("tchannel-name")
             .register("endpoint", new ThriftAsyncRequestHandler<Example, Example>() {

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
@@ -187,6 +187,8 @@ public class TracingPropagationTest {
     private static class ThriftAsyncHandler extends ThriftAsyncRequestHandler<Example, Example> {
         @Override
         public ListenableFuture<ThriftResponse<Example>> handleImpl(final ThriftRequest<Example> request) {
+            // To make downstream calls the original thread should be released therefore a future is
+            // setup and returned. This also simulates the behavior of a real handler impl better.
             final SettableFuture<ThriftResponse<Example>> responseFuture = SettableFuture.create();
             ListeningExecutorService service = MoreExecutors.listeningDecorator(
                 Executors.newFixedThreadPool(1));


### PR DESCRIPTION
- Both types are meant to support async handling of requests. AsyncRequestHandler provides
  a way for handler to return a future rather than a synchonous response like the
  RequestHandler.
- ThriftAsyncRequestHandler further scopes it down to Thrift handlers and allowing those to
  return futures

This should resolve https://github.com/uber/tchannel-java/issues/72

 @abhinav and @vivekrsharma you guys might be interested.
