### PR TITLE
Remove sub channel duplicate

### DIFF
--- a/tchannel-example/src/main/java/com/uber/tchannel/basic/AsyncRequest.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/basic/AsyncRequest.java
@@ -33,13 +33,13 @@ import com.uber.tchannel.messages.RawResponse;
 
 import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class AsyncRequest {
     public static void main(String[] args) throws Exception {
         TChannel server = createServer();
         TChannel client = createClient();
 
+        // create sub channel to talk to server
         SubChannel subChannel = client.makeSubChannel("server");
 
         final long start = System.currentTimeMillis();
@@ -85,7 +85,7 @@ public class AsyncRequest {
         client.shutdown(false);
     }
 
-    protected static TChannel createServer() throws Exception {
+    private static TChannel createServer() throws Exception {
 
         // create TChannel
         TChannel tchannel = new TChannel.Builder("server")
@@ -129,14 +129,9 @@ public class AsyncRequest {
         return tchannel;
     }
 
-    protected static TChannel createClient() throws Exception {
-
+    private static TChannel createClient() throws Exception {
         // create TChannel
-        TChannel tchannel = new TChannel.Builder("client")
+        return new TChannel.Builder("client")
             .build();
-
-        // create sub channel to talk to server
-        tchannel.makeSubChannel("server");
-        return tchannel;
     }
 }

--- a/tchannel-example/src/main/java/com/uber/tchannel/basic/SyncRequest.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/basic/SyncRequest.java
@@ -37,6 +37,7 @@ public class SyncRequest {
         TChannel server = createServer();
         TChannel client = createClient();
 
+        // create sub channel to talk to server
         SubChannel subChannel = client.makeSubChannel("server");
 
         final long start = System.currentTimeMillis();
@@ -75,7 +76,7 @@ public class SyncRequest {
         client.shutdown(false);
     }
 
-    protected static TChannel createServer() throws Exception {
+    private static TChannel createServer() throws Exception {
 
         // create TChannel
         TChannel tchannel = new TChannel.Builder("server")
@@ -119,14 +120,9 @@ public class SyncRequest {
         return tchannel;
     }
 
-    protected static TChannel createClient() throws Exception {
-
+    private static TChannel createClient() throws Exception {
         // create TChannel
-        TChannel tchannel = new TChannel.Builder("client")
+        return new TChannel.Builder("client")
             .build();
-
-        // create sub channel to talk to server
-        tchannel.makeSubChannel("server");
-        return tchannel;
     }
 }


### PR DESCRIPTION
Small change:
- removed double creation of sub channels in two examples;
- `protected -> private` in the same two examples.