### PR TITLE
Update jaeger and opentracing versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,12 +152,12 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
-                <version>0.20.10</version>
+                <version>0.30.0</version>
             </dependency>
             <dependency>
                 <groupId>com.uber.jaeger</groupId>
                 <artifactId>jaeger-core</artifactId>
-                <version>0.17.0</version>
+                <version>0.20.6</version>
             </dependency>
             <dependency>
                 <groupId>org.openjdk.jmh</groupId>
@@ -171,7 +171,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <build>
         <plugins>
             <!-- Compiler Plugin -->
@@ -393,5 +393,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
@@ -335,7 +335,7 @@ public class TracingPropagationTest {
         String baggage = "Baggage-" + System.currentTimeMillis();
         span.setBaggageItem(BAGGAGE_KEY, baggage);
         if (!sampled) {
-            Tags.SAMPLING_PRIORITY.set(span, (short) 0);
+            Tags.SAMPLING_PRIORITY.set(span, 0);
         }
         tracingContext.pushSpan(span);
 

--- a/tchannel-crossdock/src/test/java/com/uber/tchannel/crossdock/TraceBehaviorTest.java
+++ b/tchannel-crossdock/src/test/java/com/uber/tchannel/crossdock/TraceBehaviorTest.java
@@ -122,7 +122,7 @@ public class TraceBehaviorTest {
         Span span = tracer.buildSpan("root").start();
         span.setBaggageItem(BAGGAGE_KEY, baggage);
         if (sampled) {
-            Tags.SAMPLING_PRIORITY.set(span, (short) 1);
+            Tags.SAMPLING_PRIORITY.set(span, 1);
         }
         tchannel.getTracingContext().pushSpan(span);
 


### PR DESCRIPTION
Latest jaeger uses opentracing 0.30 which has incompatible changes
with previous versions.