### PR TITLE
Add request span interceptors

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/tracing/RequestSpanInterceptor.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/tracing/RequestSpanInterceptor.java
@@ -5,14 +5,14 @@ import io.opentracing.Span;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A {@link TracingContext} implementation decorated with this interface will get an option to intercept the inbound or
- * outgoing request right after the tracing {@link Span} has been created.
+ * A {@link TracingContext} implementation decorated with this interface will get an option to intercept an inbound
+ * and/or outgoing request right after the tracing {@link Span} has been created and populated.
  */
 public interface RequestSpanInterceptor {
 
     /**
-     * This method will be invoked right after the inbound request span has been created, allowing the implementation
-     * to inspect the request and/or additional baggage from the span context.
+     * This method will be invoked right after the inbound request span has been created, allowing the implementation to
+     * inspect the request and/or additional baggage from the span context.
      *
      * @throws RuntimeException
      *     if the inbound request should fail immediately

--- a/tchannel-core/src/main/java/com/uber/tchannel/tracing/RequestSpanInterceptor.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/tracing/RequestSpanInterceptor.java
@@ -1,0 +1,31 @@
+package com.uber.tchannel.tracing;
+
+import com.uber.tchannel.messages.Request;
+import io.opentracing.Span;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A {@link TracingContext} implementation decorated with this interface will get an option to intercept the inbound or
+ * outgoing request right after the tracing {@link Span} has been created.
+ */
+public interface RequestSpanInterceptor {
+
+    /**
+     * This method will be invoked right after the inbound request span has been created, allowing the implementation
+     * to inspect the request and/or additional baggage from the span context.
+     *
+     * @throws RuntimeException
+     *     if the inbound request should fail immediately
+     */
+    void interceptInbound(@NotNull Request request, @NotNull Span span) throws RuntimeException;
+
+    /**
+     * This method will be invoked right after the outgoing request span has been created, allowing the implementation
+     * to inspect the request and/or attach additional baggage to the span context.
+     *
+     * @throws RuntimeException
+     *     if the outbound request should fail immediately
+     */
+    void interceptOutbound(@NotNull Request request, @NotNull Span span) throws RuntimeException;
+
+}


### PR DESCRIPTION
This change allows to decorate a `TracingContext` implementation with the new `RequestSpanInterceptor` interface, providing an ability to intercept incoming and/or outgoing requests right after their tracing `Span`s have been created (and populated with their baggage).

The decorated implementation can inspect the `Request` and corresponding `Span` and validate these and/or tweak the span baggage.

If the interceptor method throws an exception the request is considered to fail immediately.