### PR TITLE
Fix potential response leak on RuntimeException/Error in TFuture callback

### DIFF
--- a/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/LargePayloadBenchmark.java
+++ b/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/LargePayloadBenchmark.java
@@ -119,7 +119,6 @@ public class LargePayloadBenchmark {
             public void onResponse(RawResponse pongResponse) {
                 if (!pongResponse.isError()) {
                     counters.actualQPS.incrementAndGet();
-                    pongResponse.release();
                 } else {
                     switch (pongResponse.getError().getErrorType()) {
                         case Busy:

--- a/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongMultiServerBenchmark.java
+++ b/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongMultiServerBenchmark.java
@@ -125,7 +125,6 @@ public class PingPongMultiServerBenchmark {
             public void onResponse(JsonResponse<Pong> pongResponse) {
                 if (!pongResponse.isError()) {
                     counters.actualQPS.incrementAndGet();
-                    pongResponse.release();
                 } else {
                     counters.errorQPS.incrementAndGet();
                 }

--- a/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongServerBenchmark.java
+++ b/tchannel-benchmark/src/main/java/com/uber/tchannel/benchmarks/PingPongServerBenchmark.java
@@ -113,7 +113,6 @@ public class PingPongServerBenchmark {
                     // uncomment the following code to enforce evaluation
                     // pongResponse.getBody(Pong.class);
                     // pongResponse.getHeaders();
-                    pongResponse.release();
                 } else {
                     // System.out.println(pongResponse.getError().getMessage());
                     switch (pongResponse.getError().getErrorType()) {

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TFuture.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TFuture.java
@@ -111,9 +111,12 @@ public final class TFuture<V extends Response> extends AbstractFuture<V> {
         super.addListener(new Runnable() {
             @Override
             public void run() {
-                listener.run();
-                if (listenerCount.decrementAndGet() == 0) {
-                    response.release();
+                try {
+                    listener.run();
+                } finally {
+                    if (listenerCount.decrementAndGet() == 0) {
+                        response.release();
+                    }
                 }
             }
         }, exec);

--- a/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
+++ b/tchannel-example/src/main/java/com/uber/tchannel/hyperbahn/HyperbahnExample.java
@@ -70,14 +70,10 @@ public final class HyperbahnExample {
         future.addCallback(new TFutureCallback<JsonResponse<AdvertiseResponse>>() {
             @Override
             public void onResponse(JsonResponse<AdvertiseResponse> response) {
-                try {
-                    if (!response.isError()) {
-                        System.out.println("Got response. All set: " + response.getBody(AdvertiseResponse.class));
-                    } else {
-                        System.out.println("Error happened: " + response.getError().getMessage());
-                    }
-                } finally {
-                    response.release();
+                if (!response.isError()) {
+                    System.out.println("Got response. All set: " + response.getBody(AdvertiseResponse.class));
+                } else {
+                    System.out.println("Error happened: " + response.getError().getMessage());
                 }
             }
         });

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
@@ -84,8 +84,6 @@ public final class HyperbahnClient {
     /**
      * Starts advertising on Hyperbahn at a fixed interval.
      *
-     * The caller of this function owns the returned buffer and it is their responsibility to release it.
-     *
      * @return a future that resolves to the response of the first advertise request
      */
     public TFuture<JsonResponse<AdvertiseResponse>> advertise() {

--- a/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
+++ b/tchannel-hyperbahn/src/main/java/com/uber/tchannel/hyperbahn/api/HyperbahnClient.java
@@ -132,13 +132,7 @@ public final class HyperbahnClient {
         advertiseTimer.schedule(new TimerTask() {
             @Override
             public void run() {
-                advertise().addCallback(new TFutureCallback<JsonResponse<AdvertiseResponse>>() {
-                    @Override
-                    public void onResponse(JsonResponse<AdvertiseResponse> response) {
-                        // We own this buffer so we should release it.
-                        response.release();
-                    }
-                });
+                advertise();
             }
         }, advertiseInterval);
     }

--- a/tchannel-hyperbahn/src/test/java/com/uber/tchannel/hyperbahn/api/HyperbahnClientTest.java
+++ b/tchannel-hyperbahn/src/test/java/com/uber/tchannel/hyperbahn/api/HyperbahnClientTest.java
@@ -85,12 +85,7 @@ public class HyperbahnClientTest {
             .setRouters(routers)
             .setAdvertiseInterval(100)
             .build();
-        hyperbahnClient.advertise().addCallback(new TFutureCallback<JsonResponse<AdvertiseResponse>>() {
-            @Override
-            public void onResponse(JsonResponse<AdvertiseResponse> response) {
-                response.release();
-            }
-        });
+        hyperbahnClient.advertise();
 
         sleep(500);
         assertTrue(responseHandler.requestsReceived >= 3);


### PR DESCRIPTION
Examples, benchmark tests, and `HyperbahnClient` adjusted to rely on `TFuture` callback handling to release the response.