### PR TITLE
Propagate response TFuture listener creator's context to the listener invocation

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
@@ -237,7 +237,7 @@ public final class SubChannel {
         InetAddress host,
         int port
     ) {
-        OutRequest<V> outRequest = new OutRequest<>(this, request);
+        OutRequest<V> outRequest = new OutRequest<>(this, request, topChannel.getTracingContext());
         if (host != null) {
             Connection conn = peerManager.findOrNew(new InetSocketAddress(host, port));
             // No retry for direct connections

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/OutRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/OutRequest.java
@@ -11,6 +11,7 @@ import com.uber.tchannel.messages.Request;
 import com.uber.tchannel.messages.Response;
 import com.uber.tchannel.messages.ResponseMessage;
 import com.uber.tchannel.messages.ThriftResponse;
+import com.uber.tchannel.tracing.TracingContext;
 import io.netty.channel.ChannelFuture;
 import io.netty.util.Timeout;
 import org.jetbrains.annotations.NotNull;
@@ -41,11 +42,21 @@ public final class OutRequest<V extends Response> {
     private @Nullable ChannelFuture channelFuture = null;
     private @Nullable ErrorResponse lastError = null;
 
-    public OutRequest(@NotNull SubChannel subChannel, @NotNull Request request) {
+    public OutRequest(
+        @NotNull SubChannel subChannel,
+        @NotNull Request request,
+        @Nullable TracingContext tracingContext
+    ) {
         this.subChannel = subChannel;
         this.request = request;
-        this.future = TFuture.create(request.getArgScheme());
+        this.future = TFuture.create(request.getArgScheme(), tracingContext);
         this.retryLimit = request.getRetryLimit();
+    }
+
+    /** @deprecated Use {@link #OutRequest(SubChannel, Request, TracingContext)}. */
+    @Deprecated
+    public OutRequest(@NotNull SubChannel subChannel, @NotNull Request request) {
+        this(subChannel, request, null);
     }
 
     public @NotNull Request getRequest() {

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTest.java
@@ -1,0 +1,132 @@
+package com.uber.tchannel.tracing;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.uber.jaeger.reporters.NoopReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.api.TFuture;
+import com.uber.tchannel.api.errors.TChannelError;
+import com.uber.tchannel.api.handlers.HealthCheckRequestHandler;
+import com.uber.tchannel.api.handlers.ThriftAsyncRequestHandler;
+import com.uber.tchannel.messages.ErrorResponse;
+import com.uber.tchannel.messages.ThriftRequest;
+import com.uber.tchannel.messages.ThriftResponse;
+import com.uber.tchannel.messages.generated.Meta;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.hamcrest.CoreMatchers;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+/**
+ * Tests asynchronous request callback tracing context propagation.
+ *
+ * @author yegor 2017-11-10.
+ */
+public class AsyncTracingContextTest {
+
+    private static final String SERVICE = "service";
+
+    private static final String META_HEALTH = "Meta::health";
+
+    private static final String META_TEST = "Meta::test";
+
+    @Test
+    public void test() throws InterruptedException, TChannelError, ExecutionException, TimeoutException {
+        Tracer tracer = new com.uber.jaeger.Tracer
+            .Builder(SERVICE, new NoopReporter(), new ConstSampler(false))
+            .build();
+        final TracingContext tracingContext = new TracingContext.ThreadLocal();
+        try (
+            final TestChannel service = new TestChannel(SERVICE, tracer, tracingContext);
+        ) {
+            final SubChannel clientChannel = service.clientChannel(SERVICE, service.addresses());
+
+            service.register(META_HEALTH, new HealthCheckRequestHandler());
+
+            service.register(META_TEST, new ThriftAsyncRequestHandler<Meta.health_args, Meta.health_result>() {
+                @Override
+                public ListenableFuture<ThriftResponse<Meta.health_result>> handleImpl(
+                    ThriftRequest<Meta.health_args> request
+                ) {
+                    final SettableFuture<ThriftResponse<Meta.health_result>> resultFuture = SettableFuture.create();
+                    try {
+                        final Span span = tracingContext.currentSpan();
+                        ListenableFuture<ThriftResponse<Meta.health_result>> responseFuture = clientChannel.send(
+                            new ThriftRequest
+                                .Builder<Meta.health_args>(SERVICE, META_HEALTH)
+                                .setBody(new Meta.health_args())
+                                .setTimeout(1000)
+                                .setRetryLimit(0)
+                                .build()
+                        );
+                        Futures.addCallback(
+                            responseFuture,
+                            new FutureCallback<ThriftResponse<Meta.health_result>>() {
+
+                                @Override
+                                public void onSuccess(
+                                    @Nullable ThriftResponse<Meta.health_result> result
+                                ) {
+                                    try {
+                                        Assert.assertThat(
+                                            "Response callback context must have a current span",
+                                            tracingContext.hasSpan(),
+                                            is(true)
+                                        );
+                                        Assert.assertThat(
+                                            "Response callback current span must be the same as the callback creator's",
+                                            tracingContext.currentSpan(),
+                                            sameInstance(span)
+                                        );
+                                        resultFuture.set(result);
+                                    } catch (AssertionError testFailure) {
+                                        resultFuture.setException(testFailure);
+                                    }
+                                }
+
+                                @Override
+                                public void onFailure(@NotNull Throwable t) {
+                                    resultFuture.setException(t);
+                                }
+
+                            },
+                            service.executor()
+                        );
+                    } catch (TChannelError tChannelError) {
+                        resultFuture.setException(tChannelError);
+                    }
+                    return resultFuture;
+                }
+            });
+
+            TFuture<ThriftResponse<Meta.health_result>> testResponseFuture = clientChannel.send(
+                new ThriftRequest
+                    .Builder<Meta.health_args>(SERVICE, META_TEST)
+                    .setBody(new Meta.health_args())
+                    .setTimeout(1000)
+                    .setRetryLimit(0)
+                    .build()
+            );
+            try (ThriftResponse<Meta.health_result> testResponse = testResponseFuture.get()) {
+                Assert.assertThat(
+                    "Response must have no errors",
+                    testResponse.getError(),
+                    CoreMatchers.nullValue(ErrorResponse.class)
+                );
+            }
+        }
+    }
+
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TestChannel.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TestChannel.java
@@ -1,0 +1,103 @@
+package com.uber.tchannel.tracing;
+
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.handlers.RequestHandler;
+import com.uber.tchannel.channels.Connection;
+import io.opentracing.Tracer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * TChannel test contraption.
+ *
+ * @author yegor 2017-11-10.
+ */
+
+public class TestChannel implements AutoCloseable {
+
+    private static final @NotNull InetAddress localhost = loopback();
+
+    private final @NotNull String name;
+
+    private final @NotNull ExecutorService executor;
+
+    private final @NotNull TChannel tchannel;
+
+    private final @NotNull SubChannel subChannel;
+
+    private final @NotNull List<InetSocketAddress> addresses;
+
+    public TestChannel(
+        @NotNull String name,
+        @Nullable Tracer tracer,
+        @Nullable TracingContext tracingContext
+    ) throws InterruptedException {
+        this.name = name;
+        executor = Executors.newSingleThreadExecutor();
+
+        TChannel.Builder tcBuilder = new TChannel.Builder(name)
+            .setServerHost(localhost)
+            .setServerPort(0)
+            .setExecutorService(executor);
+        if (tracer != null) {
+            tcBuilder.setTracer(tracer);
+        }
+        if (tracingContext != null) {
+            tcBuilder.setTracingContext(tracingContext);
+        }
+        tchannel = tcBuilder.build();
+
+        subChannel = tchannel.makeSubChannel(name, Connection.Direction.IN);
+        tchannel.listen().sync();
+        addresses = Collections.singletonList(new InetSocketAddress(localhost, tchannel.getListeningPort()));
+    }
+
+    private static @NotNull InetAddress loopback() {
+        try {
+            return InetAddress.getByAddress(new byte[]{ 127, 0, 0, 1 });
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public @NotNull String name() {
+        return name;
+    }
+
+    public @NotNull ExecutorService executor() {
+        return executor;
+    }
+
+    public @NotNull List<InetSocketAddress> addresses() {
+        return addresses;
+    }
+
+    public void register(@NotNull String endpoint, RequestHandler handler) {
+        subChannel.register(endpoint, handler);
+    }
+
+    public @NotNull SubChannel clientChannel(
+        @NotNull String peerName,
+        @NotNull List<InetSocketAddress> peerAddresses
+    ) {
+        return tchannel
+            .makeSubChannel(peerName, Connection.Direction.OUT)
+            .setPeers(peerAddresses);
+    }
+
+    @Override
+    public void close() {
+        tchannel.shutdown();
+        executor.shutdown();
+    }
+
+}


### PR DESCRIPTION
Currently, caller's tracing context is lost when response `TFuture` listeners are invoked.

This patch fixes the behavior by allowing response `TFuture` to capture the listener creator's context and wrapping the listener invocation with it.