### PR TITLE
Removing gson exclusion from Jaeger dependency configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,12 +164,6 @@
                 <groupId>com.uber.jaeger</groupId>
                 <artifactId>jaeger-core</artifactId>
                 <version>0.23.0</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.gson</groupId>
-                        <artifactId>gson</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
Result of chat with @yborovikov 

Changelog between gson 2.8.1 and 2.8.2
- Introduced a new API, JsonElement.deepCopy()
- Numerous other bugfixes

{[Full diff](https://github.com/google/gson/compare/gson-parent-2.8.1...gson-parent-2.8.2)}