### PR TITLE
Add OpenTracingContext implementation

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -33,6 +33,7 @@ import com.uber.tchannel.handlers.MessageFragmenter;
 import com.uber.tchannel.handlers.RequestRouter;
 import com.uber.tchannel.handlers.ResponseRouter;
 import com.uber.tchannel.messages.Request;
+import com.uber.tchannel.tracing.OpenTracingContext;
 import com.uber.tchannel.tracing.TracingContext;
 import com.uber.tchannel.utils.TChannelUtilities;
 import io.netty.bootstrap.Bootstrap;
@@ -109,7 +110,9 @@ public final class TChannel {
         this.timer = builder.timer;
         this.clientMaxPendingRequests = builder.clientMaxPendingRequests;
         this.tracer = builder.tracer;
-        this.tracingContext = builder.tracingContext;
+        this.tracingContext = builder.tracingContext == null
+            ? tracer == null ? new TracingContext.Default() : new OpenTracingContext(tracer.scopeManager())
+            : builder.tracingContext;
     }
 
     public String getListeningHost() {
@@ -247,7 +250,7 @@ public final class TChannel {
         private static final int WRITE_BUFFER_HIGH_WATER_MARK = 32 * 1024;
 
         private Tracer tracer;
-        private TracingContext tracingContext = new TracingContext.Default();
+        private TracingContext tracingContext;
         private ExecutorService executorService = null;
 
         public Builder(@NotNull String service) {

--- a/tchannel-core/src/main/java/com/uber/tchannel/tracing/OpenTracingContext.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/tracing/OpenTracingContext.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.tchannel.tracing;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EmptyStackException;
+
+/**
+ * An implementation of {@link TracingContext} backed by OpenTracing {@link ScopeManager} for tracing context
+ * propagation.
+ *
+ * @author yegor 2018-02-11.
+ */
+public class OpenTracingContext implements TracingContext {
+
+    private final @NotNull ScopeManager scopeManager;
+
+    /**
+     * Constructs a new instance of {@link OpenTracingContext}.
+     *
+     * @param scopeManager
+     *     a {@link ScopeManager} instance responsible for tracing context management; one can be obtained from
+     *     {@link io.opentracing.Tracer#scopeManager()}
+     */
+    public OpenTracingContext(@NotNull ScopeManager scopeManager) {
+        this.scopeManager = scopeManager;
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public void pushSpan(@NotNull Span span) {
+        scopeManager.activate(span, false);
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public boolean hasSpan() {
+        return scopeManager.active() != null;
+    }
+
+    @Override
+    public @NotNull Span currentSpan() throws EmptyStackException {
+        @SuppressWarnings("resource") Scope scope = scopeManager.active();
+        if (scope == null) {
+            throw new EmptyStackException();
+        } else {
+            return scope.span();
+        }
+    }
+
+    @Override
+    public @NotNull Span popSpan() throws EmptyStackException {
+        try (Scope scope = scopeManager.active()) {
+            if (scope == null) {
+                throw new EmptyStackException();
+            } else {
+                return scope.span();
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public void clear() {
+        Scope scope;
+        while ((scope = scopeManager.active()) != null) {
+            scope.close();
+        }
+    }
+
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncOpenTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncOpenTracingContextTest.java
@@ -21,17 +21,20 @@
  */
 package com.uber.tchannel.tracing;
 
-import com.uber.jaeger.Tracer;
+import io.opentracing.Tracer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Tests {@link TracingContext.ThreadLocal} implementation of {@link TracingContext} interface.
+ * Tests asynchronous request callback tracing context propagation with {@link OpenTracingContext} implementation of
+ * {@link TracingContext} interface.
+ *
+ * @author yegor 2017-11-10.
  */
-public class TracingContextTest extends TracingContextTestBase {
+public class AsyncOpenTracingContextTest extends AsyncTracingContextTestBase {
 
     @Override
     protected @NotNull TracingContext tracingContext(@NotNull Tracer tracer) {
-        return new TracingContext.ThreadLocal();
+        return new OpenTracingContext(tracer.scopeManager());
     }
 
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTest.java
@@ -1,132 +1,40 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.uber.tchannel.tracing;
 
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import com.uber.jaeger.reporters.NoopReporter;
-import com.uber.jaeger.samplers.ConstSampler;
-import com.uber.tchannel.api.SubChannel;
-import com.uber.tchannel.api.TFuture;
-import com.uber.tchannel.api.errors.TChannelError;
-import com.uber.tchannel.api.handlers.HealthCheckRequestHandler;
-import com.uber.tchannel.api.handlers.ThriftAsyncRequestHandler;
-import com.uber.tchannel.messages.ErrorResponse;
-import com.uber.tchannel.messages.ThriftRequest;
-import com.uber.tchannel.messages.ThriftResponse;
-import com.uber.tchannel.messages.generated.Meta;
-import io.opentracing.Span;
 import io.opentracing.Tracer;
-import org.hamcrest.CoreMatchers;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
-
-import javax.annotation.Nullable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
 
 /**
- * Tests asynchronous request callback tracing context propagation.
+ * Tests asynchronous request callback tracing context propagation with {@link TracingContext.ThreadLocal}
+ * implementation of {@link TracingContext} interface.
  *
  * @author yegor 2017-11-10.
  */
-public class AsyncTracingContextTest {
+public class AsyncTracingContextTest extends AsyncTracingContextTestBase {
 
-    private static final String SERVICE = "service";
-
-    private static final String META_HEALTH = "Meta::health";
-
-    private static final String META_TEST = "Meta::test";
-
-    @Test
-    public void test() throws InterruptedException, TChannelError, ExecutionException, TimeoutException {
-        Tracer tracer = new com.uber.jaeger.Tracer
-            .Builder(SERVICE, new NoopReporter(), new ConstSampler(false))
-            .build();
-        final TracingContext tracingContext = new TracingContext.ThreadLocal();
-        try (
-            final TestChannel service = new TestChannel(SERVICE, tracer, tracingContext);
-        ) {
-            final SubChannel clientChannel = service.clientChannel(SERVICE, service.addresses());
-
-            service.register(META_HEALTH, new HealthCheckRequestHandler());
-
-            service.register(META_TEST, new ThriftAsyncRequestHandler<Meta.health_args, Meta.health_result>() {
-                @Override
-                public ListenableFuture<ThriftResponse<Meta.health_result>> handleImpl(
-                    ThriftRequest<Meta.health_args> request
-                ) {
-                    final SettableFuture<ThriftResponse<Meta.health_result>> resultFuture = SettableFuture.create();
-                    try {
-                        final Span span = tracingContext.currentSpan();
-                        ListenableFuture<ThriftResponse<Meta.health_result>> responseFuture = clientChannel.send(
-                            new ThriftRequest
-                                .Builder<Meta.health_args>(SERVICE, META_HEALTH)
-                                .setBody(new Meta.health_args())
-                                .setTimeout(1000)
-                                .setRetryLimit(0)
-                                .build()
-                        );
-                        Futures.addCallback(
-                            responseFuture,
-                            new FutureCallback<ThriftResponse<Meta.health_result>>() {
-
-                                @Override
-                                public void onSuccess(
-                                    @Nullable ThriftResponse<Meta.health_result> result
-                                ) {
-                                    try {
-                                        Assert.assertThat(
-                                            "Response callback context must have a current span",
-                                            tracingContext.hasSpan(),
-                                            is(true)
-                                        );
-                                        Assert.assertThat(
-                                            "Response callback current span must be the same as the callback creator's",
-                                            tracingContext.currentSpan(),
-                                            sameInstance(span)
-                                        );
-                                        resultFuture.set(result);
-                                    } catch (AssertionError testFailure) {
-                                        resultFuture.setException(testFailure);
-                                    }
-                                }
-
-                                @Override
-                                public void onFailure(@NotNull Throwable t) {
-                                    resultFuture.setException(t);
-                                }
-
-                            },
-                            service.executor()
-                        );
-                    } catch (TChannelError tChannelError) {
-                        resultFuture.setException(tChannelError);
-                    }
-                    return resultFuture;
-                }
-            });
-
-            TFuture<ThriftResponse<Meta.health_result>> testResponseFuture = clientChannel.send(
-                new ThriftRequest
-                    .Builder<Meta.health_args>(SERVICE, META_TEST)
-                    .setBody(new Meta.health_args())
-                    .setTimeout(1000)
-                    .setRetryLimit(0)
-                    .build()
-            );
-            try (ThriftResponse<Meta.health_result> testResponse = testResponseFuture.get()) {
-                Assert.assertThat(
-                    "Response must have no errors",
-                    testResponse.getError(),
-                    CoreMatchers.nullValue(ErrorResponse.class)
-                );
-            }
-        }
+    @Override
+    protected @NotNull TracingContext tracingContext(@NotNull Tracer tracer) {
+        return new TracingContext.ThreadLocal();
     }
 
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTestBase.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTestBase.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.tchannel.tracing;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.uber.jaeger.reporters.NoopReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.api.TFuture;
+import com.uber.tchannel.api.errors.TChannelError;
+import com.uber.tchannel.api.handlers.HealthCheckRequestHandler;
+import com.uber.tchannel.api.handlers.ThriftAsyncRequestHandler;
+import com.uber.tchannel.messages.ErrorResponse;
+import com.uber.tchannel.messages.ThriftRequest;
+import com.uber.tchannel.messages.ThriftResponse;
+import com.uber.tchannel.messages.generated.Meta;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.hamcrest.CoreMatchers;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+/**
+ * Base for tests of asynchronous request callback tracing context propagation for various implementations of
+ * {@link TracingContext} interface.
+ *
+ * @author yegor 2017-11-10.
+ */
+public abstract class AsyncTracingContextTestBase {
+
+    private static final String SERVICE = "service";
+
+    private static final String META_HEALTH = "Meta::health";
+
+    private static final String META_TEST = "Meta::test";
+
+    protected abstract @NotNull TracingContext tracingContext(@NotNull Tracer tracer);
+
+    @Test
+    public void test() throws InterruptedException, TChannelError, ExecutionException, TimeoutException {
+        Tracer tracer = new com.uber.jaeger.Tracer
+            .Builder(SERVICE, new NoopReporter(), new ConstSampler(false))
+            .build();
+        final TracingContext tracingContext = tracingContext(tracer);
+        try (
+            final TestChannel service = new TestChannel(SERVICE, tracer, tracingContext);
+        ) {
+            final SubChannel clientChannel = service.clientChannel(SERVICE, service.addresses());
+
+            service.register(META_HEALTH, new HealthCheckRequestHandler());
+
+            service.register(META_TEST, new ThriftAsyncRequestHandler<Meta.health_args, Meta.health_result>() {
+                @Override
+                public ListenableFuture<ThriftResponse<Meta.health_result>> handleImpl(
+                    ThriftRequest<Meta.health_args> request
+                ) {
+                    final SettableFuture<ThriftResponse<Meta.health_result>> resultFuture = SettableFuture.create();
+                    try {
+                        final Span span = tracingContext.currentSpan();
+                        ListenableFuture<ThriftResponse<Meta.health_result>> responseFuture = clientChannel.send(
+                            new ThriftRequest
+                                .Builder<Meta.health_args>(SERVICE, META_HEALTH)
+                                .setBody(new Meta.health_args())
+                                .setTimeout(1000)
+                                .setRetryLimit(0)
+                                .build()
+                        );
+                        Futures.addCallback(
+                            responseFuture,
+                            new FutureCallback<ThriftResponse<Meta.health_result>>() {
+
+                                @Override
+                                public void onSuccess(
+                                    @Nullable ThriftResponse<Meta.health_result> result
+                                ) {
+                                    try {
+                                        Assert.assertThat(
+                                            "Response callback context must have a current span",
+                                            tracingContext.hasSpan(),
+                                            is(true)
+                                        );
+                                        Assert.assertThat(
+                                            "Response callback current span must be the same as the callback creator's",
+                                            tracingContext.currentSpan(),
+                                            sameInstance(span)
+                                        );
+                                        resultFuture.set(result);
+                                    } catch (AssertionError testFailure) {
+                                        // assertion error (if any) will re-surface when the future result is accessed
+                                        resultFuture.setException(testFailure);
+                                    }
+                                }
+
+                                @Override
+                                public void onFailure(@NotNull Throwable t) {
+                                    resultFuture.setException(t);
+                                }
+
+                            },
+                            service.executor()
+                        );
+                    } catch (TChannelError tChannelError) {
+                        resultFuture.setException(tChannelError);
+                    }
+                    return resultFuture;
+                }
+            });
+
+            TFuture<ThriftResponse<Meta.health_result>> testResponseFuture = clientChannel.send(
+                new ThriftRequest
+                    .Builder<Meta.health_args>(SERVICE, META_TEST)
+                    .setBody(new Meta.health_args())
+                    .setTimeout(1000)
+                    .setRetryLimit(0)
+                    .build()
+            );
+            try (ThriftResponse<Meta.health_result> testResponse = testResponseFuture.get()) {
+                Assert.assertThat(
+                    "Response must have no errors",
+                    testResponse.getError(),
+                    CoreMatchers.nullValue(ErrorResponse.class)
+                );
+            }
+        }
+    }
+
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/OpenTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/OpenTracingContextTest.java
@@ -25,13 +25,15 @@ import com.uber.jaeger.Tracer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Tests {@link TracingContext.ThreadLocal} implementation of {@link TracingContext} interface.
+ * Tests {@link OpenTracingContext} implementation of {@link TracingContext} interface.
+ *
+ * @author yegor 2018-02-13.
  */
-public class TracingContextTest extends TracingContextTestBase {
+public class OpenTracingContextTest extends TracingContextTestBase {
 
     @Override
     protected @NotNull TracingContext tracingContext(@NotNull Tracer tracer) {
-        return new TracingContext.ThreadLocal();
+        return new OpenTracingContext(tracer.scopeManager());
     }
 
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingContextTestBase.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingContextTestBase.java
@@ -1,0 +1,97 @@
+package com.uber.tchannel.tracing;
+
+import com.uber.jaeger.Tracer;
+import com.uber.jaeger.reporters.InMemoryReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.Span;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.EmptyStackException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Base for various {@link TracingContext} implementations tests.
+ *
+ * @author yegor 2018-02-13.
+ */
+public abstract class TracingContextTestBase {
+
+    private final @NotNull InMemoryReporter reporter = new InMemoryReporter();
+
+    @SuppressWarnings("resource") // closed in tearDown()
+    private final @NotNull Tracer tracer = new Tracer.Builder(
+        "tchannel-name", reporter, new ConstSampler(true)
+    ).build();
+
+    private final @NotNull TracingContext tracingContext;
+
+    @SuppressWarnings("JUnitTestCaseWithNonTrivialConstructors")
+    protected TracingContextTestBase() {
+        tracingContext = tracingContext(tracer);
+    }
+
+    protected abstract @NotNull TracingContext tracingContext(@NotNull Tracer tracer);
+
+    @After
+    public void tearDown() {
+        tracer.close();
+        reporter.close();
+    }
+
+    @Test
+    public void testTracingContextNoCurrent() {
+        try {
+            tracingContext.currentSpan();
+            fail("Expected an EmptyStackException");
+        } catch (EmptyStackException ignored) {}
+    }
+
+    @Test
+    public void testTracingContextCannotPop() {
+        try {
+            tracingContext.popSpan();
+            fail("Expected an EmptyStackException");
+        } catch (EmptyStackException ignored) {}
+    }
+
+    @Test
+    public void testTracingContext() {
+        assertFalse(tracingContext.hasSpan());
+        Span span = tracer.buildSpan("test").start();
+        tracingContext.pushSpan(span);
+        assertTrue(tracingContext.hasSpan());
+        assertEquals(span, tracingContext.currentSpan());
+        assertEquals(span, tracingContext.popSpan());
+        assertFalse(tracingContext.hasSpan());
+
+        Span span1 = tracer.buildSpan("test").start();
+        Span span2 = tracer.buildSpan("test").start();
+        tracingContext.pushSpan(span1);
+        tracingContext.pushSpan(span2);
+        assertEquals(span2, tracingContext.currentSpan());
+        assertEquals(span2, tracingContext.popSpan());
+        assertEquals(span1, tracingContext.popSpan());
+        assertFalse(tracingContext.hasSpan());
+    }
+
+    @Test
+    public void testTracingContextThreadLocal() throws InterruptedException {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Span span = tracer.buildSpan("test").start();
+                tracingContext.pushSpan(span);
+                assertTrue("Have span in worker thread", tracingContext.hasSpan());
+            }
+        });
+        thread.join();
+        assertFalse("No span in main thread", tracingContext.hasSpan());
+    }
+
+}


### PR DESCRIPTION
This PR adds an `io.opentracing.ScopeManager`-based implementation of `TracingContext`.