### PR TITLE
Propagate ErrorType to caller if ProtocolError is thrown by handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ after_success:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
   - export DOCKER=$(if [ "$CROSSDOCK" == "true" ]; then echo docker; else echo true; fi)
-  - $DOCKER login -u $DOCKER_USER -p $DOCKER_PASS
+  - echo "$DOCKER_PASS" | $DOCKER login -u "$DOCKER_USER" --password-stdin
   - $DOCKER build -f tchannel-crossdock/Dockerfile -t $REPO:$COMMIT tchannel-crossdock
   - $DOCKER tag $REPO:$COMMIT $REPO:$TAG
   - $DOCKER tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/RequestRouterTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/RequestRouterTest.java
@@ -1,0 +1,118 @@
+package com.uber.tchannel.handlers;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.TFuture;
+import com.uber.tchannel.api.handlers.AsyncRequestHandler;
+import com.uber.tchannel.errors.BusyError;
+import com.uber.tchannel.errors.ErrorType;
+import com.uber.tchannel.messages.RawRequest;
+import com.uber.tchannel.messages.RawResponse;
+import com.uber.tchannel.messages.Request;
+import com.uber.tchannel.messages.Response;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class RequestRouterTest {
+
+    private static TChannel tchannel;
+
+    private static SubChannel subChannel;
+
+    private static ThrowingAsyncHandler handler;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        handler = new ThrowingAsyncHandler();
+
+        tchannel = new TChannel.Builder("tchannel-name")
+            .setServerHost(InetAddress.getByName(null))
+            .build();
+
+        subChannel = tchannel.makeSubChannel("service")
+            .register("endpoint", handler);
+
+        tchannel.listen();
+    }
+
+    @Test
+    public void returnUnexpectedErrorOnThrowable() throws Exception {
+        handler.setThrowable(new RuntimeException());
+
+        RawRequest req = new RawRequest.Builder("service", "endpoint").build();
+
+        TFuture<RawResponse> responseTFuture = subChannel.send(
+            req,
+            tchannel.getHost(),
+            tchannel.getListeningPort()
+        );
+
+        RawResponse response = responseTFuture.get();
+
+        assertThat(
+            "Failed future must result in an error",
+            response.getError(),
+            notNullValue()
+        );
+
+        assertThat(
+            "Throwable must be mapped to ErrorType.UnexpectedError",
+            response.getError().getErrorType(),
+            equalTo(ErrorType.UnexpectedError)
+        );
+    }
+
+    @Test
+    public void propagateErrorCodeOnProtocolError() throws Exception {
+        handler.setThrowable(new BusyError("busy", null, 0));
+
+        RawRequest req = new RawRequest.Builder("service", "endpoint").build();
+
+        TFuture<RawResponse> responseTFuture = subChannel.send(
+            req,
+            tchannel.getHost(),
+            tchannel.getListeningPort()
+        );
+
+        RawResponse response = responseTFuture.get();
+
+        assertThat(
+            "Failed future must result in an error",
+            response.getError(),
+            notNullValue()
+        );
+
+        assertThat(
+            "ProtocolError must be mapped to its ErrorType",
+            response.getError().getErrorType(),
+            equalTo(ErrorType.Busy)
+        );
+    }
+
+    private static class ThrowingAsyncHandler implements AsyncRequestHandler {
+
+        private Throwable throwable;
+
+        @Override
+        public ListenableFuture<? extends Response> handleAsync(Request request) {
+            return Futures.immediateFailedFuture(throwable);
+        }
+
+        @Override
+        public Response handle(Request request) {
+            throw new UnsupportedOperationException();
+        }
+
+        public void setThrowable(Throwable throwable) {
+            this.throwable = throwable;
+        }
+    }
+}


### PR DESCRIPTION
Allow clients to set the response `ErrorType` by throwing a `ProtocolError`. Rate limiting is one use-case where this is useful.