### PR TITLE
upgrade java compiler source to 1.8 and add a type annotations for Re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <!-- store method parameter names in the bytecode (java 8+) -->
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java
@@ -242,7 +242,7 @@ public final class SubChannel {
         return send(request, null, 0);
     }
 
-    protected <V extends Response> TFuture<V> sendRequest(
+    protected <V extends @NotNull Response> TFuture<V> sendRequest(
         Request request,
         InetAddress host,
         int port


### PR DESCRIPTION
To justify the use of `response.close()` which people often use, we need to specify `NotNull` for Response, so I added a type annotation. It failed with an error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project tchannel-core: Compilation failure
[ERROR] /home/henry/share/company/uber/tchannel-java/tchannel-core/src/main/java/com/uber/tchannel/api/SubChannel.java:[245,27] type annotations are not supported in -source 1.7
[ERROR]   (use -source 8 or higher to enable type annotations)
[ERROR] 
```

This conflicts with the comment in pom.xml:
```
<!-- store method parameter names in the bytecode (java 8+) -->
```

It seems we forgot to specify java 8. So I modified it. That is how this diff comes.
