### PR TITLE
Upgrade opentracing & jaeger lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <jmh.version>1.19</jmh.version>
         <se.eris.notnull.instrument>false</se.eris.notnull.instrument><!-- off by default -->
         <slf4j.version>1.7.25</slf4j.version>
+        <opentracing.version>0.32.0</opentracing.version>
 
     </properties>
 
@@ -163,12 +164,17 @@
             <dependency>
                 <groupId>io.opentracing</groupId>
                 <artifactId>opentracing-api</artifactId>
-                <version>0.31.0</version>
+                <version>${opentracing.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.uber.jaeger</groupId>
+                <groupId>io.opentracing</groupId>
+                <artifactId>opentracing-noop</artifactId>
+                <version>${opentracing.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jaegertracing</groupId>
                 <artifactId>jaeger-core</artifactId>
-                <version>0.23.0</version>
+                <version>0.35.5</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>

--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -78,22 +78,6 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
         </dependency>
-        <!-- test dependencies -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.uber.jaeger</groupId>
-            <artifactId>jaeger-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
@@ -118,6 +102,32 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-noop</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTestBase.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/AsyncTracingContextTestBase.java
@@ -25,8 +25,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.uber.jaeger.reporters.NoopReporter;
-import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.tchannel.api.SubChannel;
 import com.uber.tchannel.api.TFuture;
 import com.uber.tchannel.api.errors.TChannelError;
@@ -36,6 +34,9 @@ import com.uber.tchannel.messages.ErrorResponse;
 import com.uber.tchannel.messages.ThriftRequest;
 import com.uber.tchannel.messages.ThriftResponse;
 import com.uber.tchannel.messages.generated.Meta;
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.NoopReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import org.hamcrest.CoreMatchers;
@@ -68,9 +69,11 @@ public abstract class AsyncTracingContextTestBase {
 
     @Test
     public void test() throws InterruptedException, TChannelError, ExecutionException, TimeoutException {
-        Tracer tracer = new com.uber.jaeger.Tracer
-            .Builder(SERVICE, new NoopReporter(), new ConstSampler(false))
+        Tracer tracer = new JaegerTracer.Builder(SERVICE)
+            .withReporter(new NoopReporter())
+            .withSampler(new ConstSampler(false))
             .build();
+
         final TracingContext tracingContext = tracingContext(tracer);
         try (
             final TestChannel service = new TestChannel(SERVICE, tracer, tracingContext);

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/NoopTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/NoopTracingContextTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015 Uber Technologies, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.uber.tchannel.tracing;
+
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpan;
+import io.opentracing.noop.NoopTracerFactory;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link OpenTracingContext} implementation of {@link TracingContext} interface.
+ *
+ * @author yegor 2018-02-13.
+ */
+public class NoopTracingContextTest extends TracingContextTestBase {
+    private TracingContext tracingContext;
+    private Tracer tracer = new JaegerTracer.Builder("noop-tracing-context")
+        .withReporter(new InMemoryReporter())
+        .withSampler(new ConstSampler(true))
+        .build();
+
+    @Override
+    protected @NotNull TracingContext tracingContext(@NotNull Tracer tracer) {
+        tracingContext = new OpenTracingContext(NoopTracerFactory.create().scopeManager());
+        return tracingContext;
+    }
+
+    @Override
+    public void testTracingContextNoCurrent() {
+        //NoopScopeManager always return default INSTANCE as active span
+        assertTrue(tracingContext.hasSpan());
+    }
+
+    @Override
+    public void testTracingContextCannotPop() {
+        //NoopScopeManager always return default INSTANCE as active span which will be popped again and again
+        assertNotNull(tracingContext.popSpan());
+    }
+
+    @Override
+    public void testTracingContext() {
+        tracingContext.clear();
+        //make sure clear won't stuck in infinite loop
+        Assert.assertTrue(true);
+    }
+
+    @Override
+    public void testTracingContextThreadLocal() throws InterruptedException {
+        final String[] spanId = new String[1];
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Span span = tracer.buildSpan("test").start();
+                spanId[0] = span.context().toSpanId();
+                tracingContext.pushSpan(span);
+                assertEquals(NoopSpan.INSTANCE, tracingContext.currentSpan());
+            }
+        });
+        thread.join();
+        assertEquals(NoopSpan.INSTANCE, tracingContext.currentSpan());
+    }
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/OpenTracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/OpenTracingContextTest.java
@@ -21,7 +21,7 @@
  */
 package com.uber.tchannel.tracing;
 
-import com.uber.jaeger.Tracer;
+import io.opentracing.Tracer;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingContextTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingContextTest.java
@@ -21,7 +21,7 @@
  */
 package com.uber.tchannel.tracing;
 
-import com.uber.jaeger.Tracer;
+import io.opentracing.Tracer;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/TracingPropagationTest.java
@@ -227,7 +227,7 @@ public class TracingPropagationTest {
         Span span = tracingContext.currentSpan();
         TraceResponse response = new TraceResponse();
         JaegerSpanContext context = (JaegerSpanContext) span.context();
-        response.traceId = context.getTraceId();
+        response.traceId = context.toTraceId();
         response.sampled = context.isSampled();
         response.baggage = span.getBaggageItem(BAGGAGE_KEY);
         try {
@@ -321,8 +321,7 @@ public class TracingPropagationTest {
     @Test
     public void testPropagation() throws Exception {
         Span span = tracer.buildSpan("root").start();
-        JaegerSpanContext context = (JaegerSpanContext) span.context();
-        String traceId = context.getTraceId();
+        String traceId = span.context().toTraceId();
         String baggage = "Baggage-" + System.currentTimeMillis();
         span.setBaggageItem(BAGGAGE_KEY, baggage);
         span.setBaggageItem(CUSTOM_BAGGAGE_PARAM_KEY, customBaggage);

--- a/tchannel-crossdock/pom.xml
+++ b/tchannel-crossdock/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.uber.jaeger</groupId>
+            <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
         </dependency>
 

--- a/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/Server.java
+++ b/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/Server.java
@@ -1,17 +1,18 @@
 
 package com.uber.tchannel.crossdock;
 
-import com.uber.jaeger.Tracer;
-import com.uber.jaeger.reporters.InMemoryReporter;
-import com.uber.jaeger.samplers.ConstSampler;
-import com.uber.jaeger.samplers.Sampler;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.api.handlers.JSONRequestHandler;
 import com.uber.tchannel.crossdock.behavior.trace.TraceBehavior;
 import com.uber.tchannel.messages.JsonRequest;
 import com.uber.tchannel.messages.JsonResponse;
 import com.uber.tchannel.tracing.TracingContext;
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.jaegertracing.spi.Sampler;
 import io.netty.channel.ChannelFuture;
+import io.opentracing.Tracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public class Server {
     public static void main(String[] args) throws UnknownHostException, InterruptedException {
         InMemoryReporter reporter = new InMemoryReporter();
         Sampler sampler = new ConstSampler(true);
-        Tracer tracer = new Tracer.Builder(SERVER_NAME, reporter, sampler).build();
+        Tracer tracer = new JaegerTracer.Builder(SERVER_NAME).withReporter(reporter).withSampler(sampler).build();
 
         HTTPServer httpServer = new HTTPServer();
         Thread httpThread = new Thread(httpServer);

--- a/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/TraceBehavior.java
+++ b/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/TraceBehavior.java
@@ -1,12 +1,12 @@
 package com.uber.tchannel.crossdock.behavior.trace;
 
-import com.uber.jaeger.SpanContext;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.crossdock.api.Downstream;
 import com.uber.tchannel.crossdock.api.ObservedSpan;
 import com.uber.tchannel.crossdock.api.Request;
 import com.uber.tchannel.crossdock.api.Response;
 import com.uber.tchannel.headers.ArgScheme;
+import io.jaegertracing.internal.JaegerSpanContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +45,10 @@ public class TraceBehavior {
         if (!tchannel.getTracingContext().hasSpan()) {
             return new ObservedSpan("no span", false, "no span");
         }
-        SpanContext spanContext = (SpanContext) tchannel.getTracingContext().currentSpan().context();
+        JaegerSpanContext spanContext = (JaegerSpanContext) tchannel.getTracingContext().currentSpan().context();
 
         return new ObservedSpan(
-                String.format("%x", spanContext.getTraceId()),
+                String.format("%s", spanContext.getTraceId()),
                 spanContext.isSampled(),
                 spanContext.getBaggageItem(BAGGAGE_KEY));
     }

--- a/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/TraceBehavior.java
+++ b/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/TraceBehavior.java
@@ -48,7 +48,7 @@ public class TraceBehavior {
         JaegerSpanContext spanContext = (JaegerSpanContext) tchannel.getTracingContext().currentSpan().context();
 
         return new ObservedSpan(
-                String.format("%s", spanContext.getTraceId()),
+                spanContext.toTraceId(),
                 spanContext.isSampled(),
                 spanContext.getBaggageItem(BAGGAGE_KEY));
     }


### PR DESCRIPTION
- upgrade opentracing to 0.32.0
- upgrade jaeger to 1.1.1
- fix the infinite loop bug when closing tracing context due to the NoopScopeManager always return non-null instance
Base on the comment: https://code.uberinternal.com/D2999387?id=9423683#inline-21546995