### PR TITLE
Allow customizing child group thread pool size

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -21,6 +21,7 @@
  */
 package com.uber.tchannel.api;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.uber.tchannel.api.handlers.RequestHandler;
 import com.uber.tchannel.channels.ChannelRegistrar;
 import com.uber.tchannel.channels.Connection;
@@ -238,8 +239,8 @@ public final class TChannel {
 
         private final @NotNull HashedWheelTimer timer;
         private static ExecutorService defaultExecutorService = null;
-        private @NotNull EventLoopGroup bossGroup;
-        private @NotNull EventLoopGroup childGroup;
+        private EventLoopGroup bossGroup;
+        private EventLoopGroup childGroup;
 
         private static final boolean useEpoll = Epoll.isAvailable();
 
@@ -338,6 +339,16 @@ public final class TChannel {
         public @NotNull Builder setTracer(Tracer tracer) {
             this.tracer = tracer;
             return this;
+        }
+
+        @VisibleForTesting
+        @Nullable EventLoopGroup getBossGroup() {
+            return bossGroup;
+        }
+
+        @VisibleForTesting
+        @Nullable EventLoopGroup getChildGroup() {
+            return childGroup;
         }
 
         /**

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -363,12 +363,16 @@ public final class TChannel {
 
         public @NotNull TChannel build() {
             logger.debug(useEpoll ? "Using native epoll transport" : "Using NIO transport");
-            bossGroup = useEpoll
-                ? new EpollEventLoopGroup(bossGroupThreads, new DefaultThreadFactory("epoll-boss-group"))
-                : new NioEventLoopGroup(bossGroupThreads, new DefaultThreadFactory("nio-boss-group"));
-            childGroup = useEpoll
-                ? new EpollEventLoopGroup(childGroupThreads, new DefaultThreadFactory("epoll-child-group"))
-                : new NioEventLoopGroup(childGroupThreads, new DefaultThreadFactory("nio-child-group"));
+            if (bossGroup == null) {
+                bossGroup = useEpoll
+                    ? new EpollEventLoopGroup(bossGroupThreads, new DefaultThreadFactory("epoll-boss-group"))
+                    : new NioEventLoopGroup(bossGroupThreads, new DefaultThreadFactory("nio-boss-group"));
+            }
+            if (childGroup == null) {
+                childGroup = useEpoll
+                    ? new EpollEventLoopGroup(childGroupThreads, new DefaultThreadFactory("epoll-child-group"))
+                    : new NioEventLoopGroup(childGroupThreads, new DefaultThreadFactory("nio-child-group"));
+            }
             return new TChannel(this);
         }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -305,12 +305,25 @@ public final class TChannel {
             return this;
         }
 
+        /**
+         * Set the number of threads used for the boss group.
+         *
+         * Default value: 1
+         *
+         * {@link #setBossGroup} takes precedence over this, if set.
+         */
         public @NotNull Builder setBossGroupThreads(int bossGroupThreads) {
             this.bossGroupThreads = bossGroupThreads;
             return this;
         }
 
-        /** Set to 0 (zero) to default to environment-based count. */
+        /**
+         * Set the number of threads used for the child group.
+         *
+         * Default value: 0 (falls back to {@code NettyRuntime.availableProcessors()})
+         *
+         * {@link #setChildGroup} takes precedence over this, if set.
+         */
         public @NotNull Builder setChildGroupThreads(int childGroupThreads) {
             this.childGroupThreads = childGroupThreads;
             return this;

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
@@ -22,6 +22,8 @@
 
 package com.uber.tchannel.api;
 
+import com.uber.tchannel.api.TChannel.Builder;
+import io.netty.util.concurrent.MultithreadEventExecutorGroup;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -49,8 +51,8 @@ public class TChannelBuilderTest {
         // InetAddress constructed using hostname will not return IP address
         // with getHostName call
         TChannel tchannel = new TChannel.Builder("some-service")
-                .setServerHost(InetAddress.getByName("localhost"))
-                .build();
+            .setServerHost(InetAddress.getByName("localhost"))
+            .build();
         tchannel.listen();
 
         // The regular expression used here doesn't cover all invalid cases, but it's
@@ -58,4 +60,16 @@ public class TChannelBuilderTest {
         assertTrue((tchannel.getListeningHost().matches("^\\d+\\.\\d+\\.\\d+\\.\\d+$")));
     }
 
+    @Test
+    public void testGroupsThreadCounts() throws Exception {
+
+        Builder builder = new Builder("some-service")
+            .setBossGroupThreads(3)
+            .setChildGroupThreads(5);
+
+        builder.build();
+
+        assertEquals(3, ((MultithreadEventExecutorGroup) builder.getBossGroup()).executorCount());
+        assertEquals(5, ((MultithreadEventExecutorGroup) builder.getChildGroup()).executorCount());
+    }
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/api/TChannelBuilderTest.java
@@ -23,12 +23,14 @@
 package com.uber.tchannel.api;
 
 import com.uber.tchannel.api.TChannel.Builder;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.concurrent.MultithreadEventExecutorGroup;
 import org.junit.Test;
 
 import java.net.InetAddress;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TChannelBuilderTest {
@@ -71,5 +73,23 @@ public class TChannelBuilderTest {
 
         assertEquals(3, ((MultithreadEventExecutorGroup) builder.getBossGroup()).executorCount());
         assertEquals(5, ((MultithreadEventExecutorGroup) builder.getChildGroup()).executorCount());
+    }
+
+    @Test
+    public void testGroupsThreadCountsIgnoredForExplicitGroups() throws Exception {
+
+        NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        NioEventLoopGroup childGroup = new NioEventLoopGroup(1);
+
+        Builder builder = new Builder("some-service")
+            .setBossGroup(bossGroup)
+            .setChildGroup(childGroup)
+            .setBossGroupThreads(3)
+            .setChildGroupThreads(5);
+
+        builder.build();
+
+        assertSame(bossGroup, builder.getBossGroup());
+        assertSame(childGroup, builder.getChildGroup());
     }
 }


### PR DESCRIPTION
The child group initialization code calls the default constructors of EpollEventLoopGroup and NioEventLoopGroup, which will construct ForkJoinPools with a maximum # of threads determined by `Runtime.getRuntime().availableProcessors()`.

For containerized applications in older JDK versions, the JVM is unable to correctly determine the number of available CPU cores. So these FJPs will likely by oversized in these scenarios.

This change allows the user to specify the number of threads used for the boss & child group thread pools. (This is already possible with `setBossGroup`/`setChildGroup` but is more convoluted.)

Extra change: also names the corresponding threads for debugging purposes.