### PR TITLE
Implement server backpressure (opt-in)

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -357,6 +357,25 @@ public final class TChannel {
             return this;
         }
 
+        /**
+         * This activates the load control mechanism. (It is disabled by default.)
+         *
+         * Each connection will keep track of the number of outstanding Requests.
+         * These are requests which haven't been resolved by a Response (successful or otherwise).
+         *
+         * Based on {@code lowWaterMark} and {@code highWaterMark}, reading from the connection will be paused/resumed
+         * to avoid practically unfulfillable load on the server. This is called backpressure.
+         * When configured correctly, this does not affect server throughput but reduces GC churn and the risk of OOM.
+         *
+         * Suggestions:
+         *   - Make sure {@code lowWaterMark} and {@code highWaterMark} are distanced. (Good: 8 and 32; Bad: 20 and 25)
+         *   - {@code highWaterMark} need not be very big. See {@link LoadControlHandler.Factory#MAX_HIGH}.
+         *
+         * @param highWaterMark when the number of outstanding request is equal to or greater than this value, reading
+         * from the connection is paused temporarily.
+         * @param lowWaterMark when the number of outstanding requests is equal to or less than this value, reading
+         * from the connection is resumed.
+         */
         public @NotNull Builder setChildLoadControl(int lowWaterMark, int highWaterMark) {
             loadControlHandlerFactory = new LoadControlHandler.Factory(lowWaterMark, highWaterMark);
             return this;

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -357,10 +357,6 @@ public final class TChannel {
             return this;
         }
 
-        public @NotNull Builder setChildLoadControl() {
-            return setChildLoadControl(8, 32);
-        }
-
         public @NotNull Builder setChildLoadControl(int lowWaterMark, int highWaterMark) {
             loadControlHandlerFactory = new LoadControlHandler.Factory(lowWaterMark, highWaterMark);
             return this;

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -409,7 +409,7 @@ public final class TChannel {
                 .childHandler(this.channelInitializer(true, topChannel))
                 .childOption(ChannelOption.SO_KEEPALIVE, true)
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-                .option(
+                .childOption(
                     ChannelOption.WRITE_BUFFER_WATER_MARK,
                     new WriteBufferWaterMark(WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_HIGH_WATER_MARK)
                 )

--- a/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/api/TChannel.java
@@ -460,7 +460,7 @@ public final class TChannel {
                     ch.pipeline().addLast("MessageFragmenter", new MessageFragmenter());
 
                     if (isServer && loadControlHandlerFactory != null) {
-                        ch.pipeline().addLast("LoadControl", loadControlHandlerFactory.create(ch.config()));
+                        ch.pipeline().addLast("LoadControl", loadControlHandlerFactory.create());
                     }
 
                     // Pass RequestHandlers to the RequestRouter

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * When the number of outstanding requests surpasses the {@link #high} water mark, reading is paused.
  *
- * When the number of outstanding requests goes blow the {@link #low} water mark, reading is resumed.
+ * When the number of outstanding requests goes below the {@link #low} water mark, reading is resumed.
  *
  * This signals the upstream producer (the client) to back off / slow down, because it will not be able to write any
  * more requests to the connection.

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
@@ -1,0 +1,77 @@
+package com.uber.tchannel.handlers;
+
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides backpressure for a Netty pipeline.
+ *
+ * Keeps track of (#reads - #writes) as {@link #outstanding}.
+ *
+ * When the number of outstanding requests surpasses the {@link #high} water mark, reading is paused.
+ *
+ * When the number of outstanding requests goes blow the {@link #low} water mark, reading is resumed.
+ *
+ * This signals the upstream producer (the client) to back off / slow down, because it will not be able to write any
+ * more requests to the connection.
+ *
+ * Note: STATEFUL HANDLER (use new instance per pipeline)
+ */
+public final class LoadControlHandler extends ChannelDuplexHandler {
+
+    private static final AtomicIntegerFieldUpdater<LoadControlHandler> OUTSTANDING_UPDATER =
+        AtomicIntegerFieldUpdater.newUpdater(LoadControlHandler.class, "outstanding");
+
+    private final ChannelConfig config;
+    private final int low;
+    private final int high;
+
+    private volatile int outstanding = 0;
+
+    private LoadControlHandler(@NotNull ChannelConfig config, int low, int high) {
+        this.config = config;
+        this.low = low;
+        this.high = high;
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) throws Exception {
+        if (OUTSTANDING_UPDATER.incrementAndGet(this) >= high && config.isAutoRead()) {
+            config.setAutoRead(false);
+        }
+        super.read(ctx);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (OUTSTANDING_UPDATER.decrementAndGet(this) <= low && !config.isAutoRead()) {
+            config.setAutoRead(true);
+        }
+        super.write(ctx, msg, promise);
+    }
+
+    public static final class Factory {
+        private final int low;
+        private final int high;
+
+        public Factory(int low, int high) {
+            if (low < 0) {
+                throw new IllegalArgumentException("invariant violation: low < 0");
+            }
+            if (high <= low) {
+                throw new IllegalArgumentException("invariant violation: high <= low");
+            }
+            this.low = low;
+            this.high = high;
+        }
+
+        public LoadControlHandler create(@NotNull ChannelConfig config) {
+            return new LoadControlHandler(Objects.requireNonNull(config), low, high);
+        }
+    }
+}

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/LoadControlHandler.java
@@ -59,6 +59,19 @@ public final class LoadControlHandler extends ChannelDuplexHandler {
     }
 
     public static final class Factory {
+
+        /**
+         * The high water mark should not be big.
+         *
+         * Queuing up outstanding requests means that the server cannot keep up with the incoming RPS.
+         * Sooner or later, the high water mark will be reached. Prefer to do this sooner and avoid OOMs.
+         *
+         * A small high water mark is more sensitive to server 'hiccups'. These are resolved quickly (thus 'hiccups'),
+         * so there is little harm.
+         * Still, there can be some unnecessary CPU churn from triggering the high water mark on and off.
+         */
+        public static final int MAX_HIGH = 100;
+
         private final int low;
         private final int high;
 
@@ -68,6 +81,9 @@ public final class LoadControlHandler extends ChannelDuplexHandler {
             }
             if (high <= low) {
                 throw new IllegalArgumentException("invariant violation: high <= low");
+            }
+            if (high > MAX_HIGH) {
+                throw new IllegalArgumentException("invariant violation: high > " + MAX_HIGH);
             }
             this.low = low;
             this.high = high;

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
@@ -195,12 +195,12 @@ public class RequestRouter extends SimpleChannelInboundHandler<Request> {
                     break;
                 }
 
-                channel.write(res, channel.voidPromise());
+                ctx.write(res, channel.voidPromise());
                 flush = true;
             }
 
             if (flush) {
-                channel.flush();
+                ctx.flush();
             }
         } finally {
             busy.set(false);

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
@@ -190,7 +190,7 @@ public class RequestRouter extends SimpleChannelInboundHandler<Request> {
                     break;
                 }
 
-                channel.write(res);
+                channel.write(res, channel.voidPromise());
                 flush = true;
             }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/RequestRouter.java
@@ -142,7 +142,12 @@ public class RequestRouter extends SimpleChannelInboundHandler<Request> {
             public void onSuccess(Response response) {
                 if (ctx.channel().isActive()) {
                     responseQueue.offer(response);
-                    sendResponse(ctx);
+                    ctx.channel().eventLoop().execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            sendResponse(ctx);
+                        }
+                    });
                 } else {
                     response.release();
                 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/LoadControlHandlerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/LoadControlHandlerTest.java
@@ -1,0 +1,173 @@
+package com.uber.tchannel.handlers;
+
+import static org.junit.Assert.assertEquals;
+
+import com.uber.tchannel.api.ResponseCode;
+import com.uber.tchannel.api.SubChannel;
+import com.uber.tchannel.api.TChannel;
+import com.uber.tchannel.api.TChannel.Builder;
+import com.uber.tchannel.api.TFuture;
+import com.uber.tchannel.api.handlers.RequestHandler;
+import com.uber.tchannel.errors.ErrorType;
+import com.uber.tchannel.messages.RawRequest;
+import com.uber.tchannel.messages.RawResponse;
+import com.uber.tchannel.messages.Request;
+import com.uber.tchannel.messages.Response;
+import java.net.InetAddress;
+import java.util.concurrent.Semaphore;
+import org.junit.Test;
+
+public class LoadControlHandlerTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invariant_lowLessThanZero() {
+        new Builder("server")
+            .setChildLoadControl(-1, 10)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invariant_highEqualToLow() {
+        new TChannel.Builder("server")
+            .setChildLoadControl(10, 10)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invariant_highLessThanLow() {
+        new TChannel.Builder("server")
+            .setChildLoadControl(10, 5)
+            .build();
+    }
+
+    /**
+     * Send two requests in parallel.
+     *
+     * One of the requests will not be resolved, because it triggers the high water mark.
+     *
+     * The request that _does_ resolve, will not trigger the low water mark.
+     *
+     * So the other request will timeout.
+     */
+    @Test
+    public void testHighWaterMark() throws Exception {
+
+        try (Scenario scenario = new Scenario(0, 2)) {
+            TFuture<RawResponse> future1 = scenario.sendRequest(100);
+            TFuture<RawResponse> future2 = scenario.sendRequest(100);
+
+            scenario.releaseResponses(2);
+
+            int success = 0;
+
+            if (ResponseCode.OK.equals(future1.get().getResponseCode())) {
+                success += 1;
+                assertEquals(ErrorType.Timeout, future2.get().getError().getErrorType());
+            }
+
+            if (ResponseCode.OK.equals(future2.get().getResponseCode())) {
+                success += 1;
+                assertEquals(ErrorType.Timeout, future1.get().getError().getErrorType());
+            }
+
+            assertEquals(1, success);
+        }
+    }
+
+    /**
+     * Send two requests in parallel.
+     *
+     * One of the requests will trigger the water mark. It will not be read.
+     *
+     * The other request will be resolved, and will trigger the low water mark.
+     *
+     * The paused request is resumed.
+     *
+     * All requests are resolved.
+     */
+    @Test
+    public void testLowWaterMark() throws Exception {
+
+        try (Scenario scenario = new Scenario(1, 2)) {
+            TFuture<RawResponse> future1 = scenario.sendRequest(100);
+            TFuture<RawResponse> future2 = scenario.sendRequest(100);
+
+            scenario.releaseResponses(2);
+
+            assertEquals(ResponseCode.OK, future1.get().getResponseCode());
+            assertEquals(ResponseCode.OK, future2.get().getResponseCode());
+        }
+    }
+
+    private static final class Scenario implements AutoCloseable {
+
+        private Semaphore responseGate;
+        private InetAddress host;
+        private TChannel server;
+        private SubChannel subServer;
+        private TChannel client;
+        private SubChannel subClient;
+
+        Scenario(int low, int high) throws Exception {
+            responseGate = new Semaphore(0);
+
+            host = InetAddress.getByName(null);
+
+            server = new TChannel.Builder("server")
+                .setServerHost(host)
+                .setChildLoadControl(low, high)
+                .build();
+
+            subServer = server.makeSubChannel("server")
+                .register("echo", new GatedResponseHandler(responseGate));
+
+            client = new TChannel.Builder("client")
+                .setServerHost(host)
+                .build();
+
+            subClient = client.makeSubChannel("server");
+
+            server.listen();
+            client.listen();
+        }
+
+        void releaseResponses(int amount) {
+            responseGate.release(amount);
+        }
+
+        TFuture<RawResponse> sendRequest(int timeout) {
+            return subClient.send(createRequest(timeout), host, server.getListeningPort());
+        }
+
+        RawRequest createRequest(int timeout) {
+            return new RawRequest.Builder("server", "echo")
+                .setTimeout(timeout)
+                .build();
+        }
+
+        @Override
+        public void close() throws Exception {
+            server.shutdown();
+            client.shutdown();
+        }
+    }
+
+    private static final class GatedResponseHandler implements RequestHandler {
+
+        private final Semaphore responseGate;
+
+        public GatedResponseHandler(Semaphore responseGate) {
+            this.responseGate = responseGate;
+        }
+
+        @Override
+        public Response handle(Request request) {
+            try {
+                responseGate.acquire();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return new RawResponse.Builder(request).build();
+        }
+    }
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/handlers/LoadControlHandlerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/handlers/LoadControlHandlerTest.java
@@ -1,5 +1,6 @@
 package com.uber.tchannel.handlers;
 
+import static com.uber.tchannel.handlers.LoadControlHandler.Factory.MAX_HIGH;
 import static org.junit.Assert.assertEquals;
 
 import com.uber.tchannel.api.ResponseCode;
@@ -42,6 +43,13 @@ public class LoadControlHandlerTest {
     public void invariant_highLessThanLow() {
         new TChannel.Builder("server")
             .setChildLoadControl(10, 5)
+            .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invariant_highTooBig() {
+        new TChannel.Builder("server")
+            .setChildLoadControl(0, MAX_HIGH + 1)
             .build();
     }
 


### PR DESCRIPTION
While trying to tackle the issue of OOM errors from having unbounded outstanding requests in asynchronous servers, I came across [this SO answer](https://stackoverflow.com/a/37713148) and [this presentation](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html).

Each commit in this branch addresses a particular slide in the presentation:

- `Add load control handler` - [slide 33](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#33.0) (this is the main change)
- `Set child WRITE_BUFFER_WATER_MARK` - [slide 11](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#11.0)
- `Use voidPromise on unused future` - [slide 8](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#8.0)
- `Send responses inside the event loop` - [slide 28](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#28.0)
- `Write to context to continue pipeline` - [slide 29](http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#29.0)

## PingPongServerBenchmark

No changes
```
Benchmark                                      Mode  Cnt       Score      Error  Units
PingPongServerBenchmark.benchmark             thrpt   50  121435.443 ± 5985.188  ops/s
PingPongServerBenchmark.benchmark:actualQPS   thrpt   50  121456.863 ± 6018.500  ops/s
PingPongServerBenchmark.benchmark:busyQPS     thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:errorQPS    thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:networkQPS  thrpt   50     190.500 ±  666.834  ops/s
PingPongServerBenchmark.benchmark:timeoutQPS  thrpt   50         ≈ 0             ops/s
```

Changes (load control = off)
```
Benchmark                                      Mode  Cnt       Score      Error  Units
PingPongServerBenchmark.benchmark             thrpt   50  132054.557 ± 6448.650  ops/s
PingPongServerBenchmark.benchmark:actualQPS   thrpt   50  132055.211 ± 6292.013  ops/s
PingPongServerBenchmark.benchmark:busyQPS     thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:errorQPS    thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:networkQPS  thrpt   50     189.710 ±  664.069  ops/s
PingPongServerBenchmark.benchmark:timeoutQPS  thrpt   50         ≈ 0             ops/s
```

Changes (load control = on)
```
Benchmark                                      Mode  Cnt       Score      Error  Units
PingPongServerBenchmark.benchmark             thrpt   50  128227.967 ± 6005.391  ops/s
PingPongServerBenchmark.benchmark:actualQPS   thrpt   50  128197.647 ± 6459.743  ops/s
PingPongServerBenchmark.benchmark:busyQPS     thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:errorQPS    thrpt   50         ≈ 0             ops/s
PingPongServerBenchmark.benchmark:networkQPS  thrpt   50     198.261 ±  694.001  ops/s
PingPongServerBenchmark.benchmark:timeoutQPS  thrpt   50         ≈ 0             ops/s
```