### PR TITLE
Release ByteBuf if ThriftHeaders can't be serialized

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftSerializer.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftSerializer.java
@@ -93,8 +93,16 @@ public class ThriftSerializer implements Serializer.SerializerInterface {
 
     @Override
     public ByteBuf encodeHeaders(@NotNull Map<String, String> applicationHeaders) {
+        boolean release = true;
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
-        CodecUtils.encodeHeaders(applicationHeaders, buf);
+        try {
+            CodecUtils.encodeHeaders(applicationHeaders, buf);
+            release = false;
+        } finally {
+            if (release) {
+                buf.release();
+            }
+        }
         return buf;
     }
 


### PR DESCRIPTION
A couple of recent stack traces:

```
ByteBuf

Recent access records: 
Created at:
	io.netty.buffer.PooledByteBufAllocator.newDirectBuffer(PooledByteBufAllocator.java:331)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:185)
	io.netty.buffer.AbstractByteBufAllocator.directBuffer(AbstractByteBufAllocator.java:171)
	io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:105)
	com.uber.tchannel.messages.ThriftSerializer.encodeHeaders(ThriftSerializer.java:96)
	com.uber.tchannel.messages.Serializer.encodeHeaders(Serializer.java:57)
	com.uber.tchannel.messages.EncodedRequest.setHeaders(EncodedRequest.java:78)
	com.uber.tchannel.tracing.Tracing.startInboundSpan(Tracing.java:138)
	com.uber.tchannel.handlers.RequestRouter.sendRequestToAsyncHandler(RequestRouter.java:225)
	com.uber.tchannel.handlers.RequestRouter.channelRead0(RequestRouter.java:131)
	com.uber.tchannel.handlers.RequestRouter.channelRead0(RequestRouter.java:55)
	io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
	io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
	io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
	io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
	io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965)
	io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
	io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:646)
	io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:581)
	io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:498)
	io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:460)
	io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	java.lang.Thread.run(Thread.java:748)
```

```
	io.netty.buffer.AdvancedLeakAwareByteBuf.writeBytes(AdvancedLeakAwareByteBuf.java:610)
	com.uber.tchannel.codecs.CodecUtils.encodeString(CodecUtils.java:78)
	com.uber.tchannel.codecs.CodecUtils.encodeHeaders(CodecUtils.java:113)
	com.uber.tchannel.messages.ThriftSerializer.encodeHeaders(ThriftSerializer.java:97)
	com.uber.tchannel.messages.Serializer.encodeHeaders(Serializer.java:57)
	com.uber.tchannel.messages.EncodedRequest$Builder.validateHeader(EncodedRequest.java:152)
	com.uber.tchannel.messages.EncodedRequest$Builder.validate(EncodedRequest.java:175)
	com.uber.tchannel.messages.ThriftRequest$Builder.validate(ThriftRequest.java:63)
	com.uber.tchannel.messages.ThriftRequest$Builder.build(ThriftRequest.java:68)
	com.company.package.handlers.request.SyncRequestHandler.constructThriftRequest(SyncRequestHandler.java:414)

```