### PR TITLE
Safe-proof memory allocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.28.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>1.4</version>

--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>opentracing-noop</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/CallRequestContinueFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/CallRequestContinueFrame.java
@@ -51,15 +51,22 @@ public final class CallRequestContinueFrame extends CallFrame {
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
 
         ByteBuf buffer = allocator.buffer(2, 6);
+        boolean release = true;
+        try {
+            // flags:1
+            buffer.writeByte(getFlags());
 
-        // flags:1
-        buffer.writeByte(getFlags());
+            // csumtype:1
+            buffer.writeByte(getChecksumType().byteValue());
 
-        // csumtype:1
-        buffer.writeByte(getChecksumType().byteValue());
-
-        // checksum -> (csum:4){0,1}
-        CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            // checksum -> (csum:4){0,1}
+            CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
 
         return buffer;
     }

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/CallRequestFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/CallRequestFrame.java
@@ -105,27 +105,34 @@ public class CallRequestFrame extends CallFrame {
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(1024);
 
-        // flags:1
-        buffer.writeByte(getFlags());
+        boolean release = true;
+        try {
+            // flags:1
+            buffer.writeByte(getFlags());
 
-        // ttl:4
-        buffer.writeInt((int) getTTL());
+            // ttl:4
+            buffer.writeInt((int) getTTL());
 
-        // tracing:25
-        CodecUtils.encodeTrace(getTracing(), buffer);
+            // tracing:25
+            CodecUtils.encodeTrace(getTracing(), buffer);
 
-        // service~1
-        CodecUtils.encodeSmallString(getService(), buffer);
+            // service~1
+            CodecUtils.encodeSmallString(getService(), buffer);
 
-        // nh:1 (hk~1, hv~1){nh}
-        CodecUtils.encodeSmallHeaders(getHeaders(), buffer);
+            // nh:1 (hk~1, hv~1){nh}
+            CodecUtils.encodeSmallHeaders(getHeaders(), buffer);
 
-        // csumtype:1
-        buffer.writeByte(getChecksumType().byteValue());
+            // csumtype:1
+            buffer.writeByte(getChecksumType().byteValue());
 
-        // (csum:4){0,1}
-        CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
-
+            // (csum:4){0,1}
+            CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/CallResponseContinueFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/CallResponseContinueFrame.java
@@ -55,14 +55,22 @@ public final class CallResponseContinueFrame extends CallFrame {
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(2, 6);
 
-        // flags:1
-        buffer.writeByte(getFlags());
+        boolean release = true;
+        try {
+            // flags:1
+            buffer.writeByte(getFlags());
 
-        // csumtype:1
-        buffer.writeByte(getChecksumType().byteValue());
+            // csumtype:1
+            buffer.writeByte(getChecksumType().byteValue());
 
-        // checksum -> (csum:4){0,1}
-        CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            // checksum -> (csum:4){0,1}
+            CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
 
         return buffer;
     }

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/CallResponseFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/CallResponseFrame.java
@@ -94,24 +94,31 @@ public final class CallResponseFrame extends CallFrame {
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(1024);
 
-        // flags:1
-        buffer.writeByte(getFlags());
+        boolean release = true;
+        try {
+            // flags:1
+            buffer.writeByte(getFlags());
 
-        // code:1
-        buffer.writeByte(getResponseCode().byteValue());
+            // code:1
+            buffer.writeByte(getResponseCode().byteValue());
 
-        // tracing:25
-        CodecUtils.encodeTrace(getTracing(), buffer);
+            // tracing:25
+            CodecUtils.encodeTrace(getTracing(), buffer);
 
-        // headers -> nh:1 (hk~1 hv~1){nh}
-        CodecUtils.encodeSmallHeaders(getHeaders(), buffer);
+            // headers -> nh:1 (hk~1 hv~1){nh}
+            CodecUtils.encodeSmallHeaders(getHeaders(), buffer);
 
-        // csumtype:1
-        buffer.writeByte(getChecksumType().byteValue());
+            // csumtype:1
+            buffer.writeByte(getChecksumType().byteValue());
 
-        // (csum:4){0,1}
-        CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
-
+            // (csum:4){0,1}
+            CodecUtils.encodeChecksum(getChecksum(), getChecksumType(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/CancelFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/CancelFrame.java
@@ -68,16 +68,22 @@ public final class CancelFrame extends Frame {
     @Override
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(31);
+        boolean release = true;
+        try {
+            // ttl:4
+            buffer.writeInt((int) getTTL());
 
-        // ttl:4
-        buffer.writeInt((int) getTTL());
+            // tracing:25
+            CodecUtils.encodeTrace(getTracing(), buffer);
 
-        // tracing:25
-        CodecUtils.encodeTrace(getTracing(), buffer);
-
-        // why~2
-        CodecUtils.encodeString(getWhy(), buffer);
-
+            // why~2
+            CodecUtils.encodeString(getWhy(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/ClaimFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/ClaimFrame.java
@@ -66,13 +66,19 @@ public final class ClaimFrame extends Frame {
     @Override
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(4 + Trace.TRACING_HEADER_LENGTH);
+        boolean release = true;
+        try {
+            // ttl: 4
+            buffer.writeInt((int) getTTL());
 
-        // ttl: 4
-        buffer.writeInt((int) getTTL());
-
-        // tracing: 25
-        CodecUtils.encodeTrace(getTracing(), buffer);
-
+            // tracing: 25
+            CodecUtils.encodeTrace(getTracing(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/ErrorFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/ErrorFrame.java
@@ -100,16 +100,22 @@ public final class ErrorFrame extends Frame {
     @Override
     public ByteBuf encodeHeader(ByteBufAllocator allocator) {
         ByteBuf buffer = allocator.buffer(28);
+        boolean release = true;
+        try {
+            // code:1
+            buffer.writeByte(getErrorType().byteValue());
 
-        // code:1
-        buffer.writeByte(getErrorType().byteValue());
+            // tracing:25
+            CodecUtils.encodeTrace(getTracing(), buffer);
 
-        // tracing:25
-        CodecUtils.encodeTrace(getTracing(), buffer);
-
-        // message~2
-        CodecUtils.encodeString(getMessage(), buffer);
-
+            // message~2
+            CodecUtils.encodeString(getMessage(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/InitRequestFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/InitRequestFrame.java
@@ -96,12 +96,19 @@ public final class InitRequestFrame extends InitFrame {
         // Allocate new ByteBuf
         ByteBuf buffer = allocator.buffer(256);
 
-        // version:2
-        buffer.writeShort(getVersion());
+        boolean release = true;
+        try {
+            // version:2
+            buffer.writeShort(getVersion());
 
-        // headers -> nh:2 (key~2 value~2){nh}
-        CodecUtils.encodeHeaders(getHeaders(), buffer);
-
+            // headers -> nh:2 (key~2 value~2){nh}
+            CodecUtils.encodeHeaders(getHeaders(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
         return buffer;
     }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/frames/InitResponseFrame.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/frames/InitResponseFrame.java
@@ -101,11 +101,19 @@ public final class InitResponseFrame extends InitFrame {
         // Allocate new ByteBuf
         ByteBuf buffer = allocator.buffer(256);
 
-        // version:2
-        buffer.writeShort(getVersion());
+        boolean release = true;
+        try {
+            // version:2
+            buffer.writeShort(getVersion());
 
-        // headers -> nh:2 (key~2 value~2){nh}
-        CodecUtils.encodeHeaders(getHeaders(), buffer);
+            // headers -> nh:2 (key~2 value~2){nh}
+            CodecUtils.encodeHeaders(getHeaders(), buffer);
+            release = false;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
 
         return buffer;
     }

--- a/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/Fixtures.java
@@ -35,6 +35,8 @@ import io.netty.buffer.Unpooled;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkState;
+
 public final class Fixtures {
 
     private Fixtures() {}
@@ -59,11 +61,10 @@ public final class Fixtures {
             null
         );
 
-        callRequestFrame.setPayload(Unpooled.wrappedBuffer(
-            callRequestFrame.encodeHeader(PooledByteBufAllocator.DEFAULT),
-            payload
-        ));
+        ByteBuf byteBuf = callRequestFrame.encodeHeader(PooledByteBufAllocator.DEFAULT);
+        callRequestFrame.setPayload(Unpooled.wrappedBuffer(byteBuf, payload));
 
+        checkState(byteBuf.refCnt() == 1);
         return callRequestFrame;
     }
 
@@ -76,11 +77,9 @@ public final class Fixtures {
                 null
         );
 
-        callRequestContinueFrame.setPayload(Unpooled.wrappedBuffer(
-            callRequestContinueFrame.encodeHeader(PooledByteBufAllocator.DEFAULT),
-            payload
-        ));
-
+        ByteBuf byteBuf = callRequestContinueFrame.encodeHeader(PooledByteBufAllocator.DEFAULT);
+        callRequestContinueFrame.setPayload(Unpooled.wrappedBuffer(byteBuf, payload));
+        checkState(byteBuf.refCnt() == 1);
         return callRequestContinueFrame;
     }
 
@@ -103,11 +102,10 @@ public final class Fixtures {
                 null
         );
 
-        callResponseFrame.setPayload(Unpooled.wrappedBuffer(
-            callResponseFrame.encodeHeader(PooledByteBufAllocator.DEFAULT),
-            payload
-        ));
+        ByteBuf byteBuf = callResponseFrame.encodeHeader(PooledByteBufAllocator.DEFAULT);
+        callResponseFrame.setPayload(Unpooled.wrappedBuffer(byteBuf, payload));
 
+        checkState(byteBuf.refCnt() == 1);
         return callResponseFrame;
     }
 
@@ -120,11 +118,9 @@ public final class Fixtures {
                 payload
         );
 
-        callResponseContinueFrame.setPayload(Unpooled.wrappedBuffer(
-            callResponseContinueFrame.encodeHeader(PooledByteBufAllocator.DEFAULT),
-            payload
-        ));
-
+        ByteBuf byteBuf = callResponseContinueFrame.encodeHeader(PooledByteBufAllocator.DEFAULT);
+        callResponseContinueFrame.setPayload(Unpooled.wrappedBuffer(byteBuf, payload));
+        checkState(byteBuf.refCnt() == 1);
         return callResponseContinueFrame;
     }
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/ResultCaptor.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/ResultCaptor.java
@@ -1,0 +1,17 @@
+package com.uber.tchannel;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class ResultCaptor<T> implements Answer {
+    private T result = null;
+    public T getResult() {
+        return result;
+    }
+
+    @Override
+    public T answer(InvocationOnMock invocationOnMock) throws Throwable {
+        result = (T) invocationOnMock.callRealMethod();
+        return result;
+    }
+}

--- a/tchannel-core/src/test/java/com/uber/tchannel/channels/ConnectionTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/channels/ConnectionTest.java
@@ -226,14 +226,14 @@ public class ConnectionTest {
         final SubChannel subClient = client.makeSubChannel("server");
         subClient.setPeers(new ArrayList<InetSocketAddress>(){
             {
-                add(new InetSocketAddress("127.0.0.1", 8888));
+                add(new InetSocketAddress(InetAddress.getLoopbackAddress(), 8888));
             }
         });
 
         RawRequest req = new RawRequest.Builder("server", "echo")
             .setHeader("title")
             .setBody("hello")
-            .setTimeout(2000)
+            .setTimeout(2500)
             .build();
 
         TFuture<RawResponse> future = subClient.send(

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallRequestFrameContinueCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallRequestFrameContinueCodecTest.java
@@ -23,14 +23,26 @@
 package com.uber.tchannel.codecs;
 
 import com.uber.tchannel.Fixtures;
+import com.uber.tchannel.ResultCaptor;
+import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.frames.CallRequestContinueFrame;
+import com.uber.tchannel.frames.CallRequestFrame;
+import com.uber.tchannel.frames.InitFrame;
+import com.uber.tchannel.tracing.Trace;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 public class CallRequestFrameContinueCodecTest {
 
@@ -54,5 +66,28 @@ public class CallRequestFrameContinueCodecTest {
 
         assertEquals("Hello, World!", inboundCallRequestContinueFrame.getPayload().toString(CharsetUtil.UTF_8));
         inboundCallRequestContinueFrame.getPayload().release();
+    }
+
+    @Test
+    public void testEncodeWithError() throws Exception {
+
+        CallRequestContinueFrame callRequestContinueFrame = new CallRequestContinueFrame(
+            42,
+            (byte) 1,
+            null,
+            0,
+            null
+        );
+        ByteBufAllocator spy = spy(ByteBufAllocator.DEFAULT);
+        ResultCaptor<ByteBuf> byteBufResultCaptor = new ResultCaptor<>();
+        doAnswer(byteBufResultCaptor).when(spy).buffer(anyInt(), anyInt());
+
+        try {
+            callRequestContinueFrame.encodeHeader(spy);
+            fail();
+        } catch (Exception ex) {
+            //expected
+        }
+        assertEquals(0, byteBufResultCaptor.getResult().refCnt());
     }
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/TFrameCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/TFrameCodecTest.java
@@ -23,13 +23,24 @@ package com.uber.tchannel.codecs;
 
 import com.uber.tchannel.frames.FrameType;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+
 import java.nio.charset.StandardCharsets;
+
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TFrameCodecTest {
 
@@ -37,18 +48,18 @@ public class TFrameCodecTest {
     public void shouldEncodeAndDecodeFrame() {
 
         EmbeddedChannel channel = new EmbeddedChannel(
-                new TChannelLengthFieldBasedFrameDecoder(),
-                new TFrameCodec()
+            new TChannelLengthFieldBasedFrameDecoder(),
+            new TFrameCodec()
         );
 
         String payload = "Hello, World!";
         ByteBuf buffer = Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8));
 
         TFrame frame = new TFrame(
-                payload.getBytes(StandardCharsets.UTF_8).length,
-                FrameType.InitRequest,
-                Integer.MAX_VALUE,
-                buffer
+            payload.getBytes(StandardCharsets.UTF_8).length,
+            FrameType.InitRequest,
+            Integer.MAX_VALUE,
+            buffer
         );
 
         channel.writeOutbound(frame);
@@ -61,6 +72,51 @@ public class TFrameCodecTest {
         assertEquals(frame.id, newFrame.id);
         newFrame.release();
 
+    }
+
+    @Test
+    public void encodeWithoutError() {
+        ByteBuf allocatedByteBuf1 = Unpooled.buffer(TFrame.FRAME_SIZE_LENGTH);
+        ByteBufAllocator allocator = Mockito.mock(ByteBufAllocator.class);
+        when(allocator.buffer(TFrame.FRAME_HEADER_LENGTH, TFrame.FRAME_HEADER_LENGTH)).thenReturn(allocatedByteBuf1);
+
+        String payload = "Hello, World!";
+        ByteBuf buffer = Unpooled.wrappedBuffer(payload.getBytes(StandardCharsets.UTF_8));
+        TFrame frame = new TFrame(
+            10,
+            FrameType.InitRequest,
+            Integer.MAX_VALUE,
+            buffer
+        );
+        TFrameCodec.encode(allocator, frame);
+
+        verify(allocator, times(1)).buffer(TFrame.FRAME_HEADER_LENGTH, TFrame.FRAME_HEADER_LENGTH);
+        assertEquals(1, allocatedByteBuf1.refCnt());
+    }
+
+    @Test
+    public void encodeWithError() {
+        ByteBuf allocatedByteBuf1 = Unpooled.buffer(TFrame.FRAME_SIZE_LENGTH);
+        ByteBufAllocator allocator = Mockito.mock(ByteBufAllocator.class);
+        when(allocator.buffer(TFrame.FRAME_HEADER_LENGTH, TFrame.FRAME_HEADER_LENGTH)).thenReturn(allocatedByteBuf1);
+
+        CompositeByteBuf buffer = Mockito.mock(CompositeByteBuf.class);
+        when(buffer.writerIndex(anyInt())).thenThrow(new RuntimeException("Can't write"));
+        TFrame frame = new TFrame(
+            10,
+            FrameType.InitRequest,
+            Integer.MAX_VALUE,
+            buffer
+        );
+        try {
+            TFrameCodec.encode(allocator, frame);
+            fail();
+        } catch (Exception e) {
+            assertEquals("Can't write", e.getMessage());
+        }
+
+        verify(allocator, times(1)).buffer(TFrame.FRAME_HEADER_LENGTH, TFrame.FRAME_HEADER_LENGTH);
+        assertEquals(0, allocatedByteBuf1.refCnt());
     }
 
 }

--- a/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/ThriftHandler.java
+++ b/tchannel-crossdock/src/main/java/com/uber/tchannel/crossdock/behavior/trace/ThriftHandler.java
@@ -83,10 +83,13 @@ class ThriftHandler extends ThriftRequestHandler<Call_args, Call_result> {
 
     private static <T> T jsonToObject(String json, Class<T> objClass) {
         ByteBuf byteBuf = UnpooledByteBufAllocator.DEFAULT.buffer(json.length());
-        byteBuf.writeBytes(json.getBytes(StandardCharsets.UTF_8));
-        T obj = new JSONSerializer().decodeBody(byteBuf, objClass);
-        byteBuf.release();
-        return obj;
+        try {
+            byteBuf.writeBytes(json.getBytes(StandardCharsets.UTF_8));
+            T obj = new JSONSerializer().decodeBody(byteBuf, objClass);
+            return obj;
+        } finally {
+            byteBuf.release();
+        }
     }
 
     private static String objectToJSON(Object obj) {


### PR DESCRIPTION
Given that `com.uber.tchannel.codecs.CodecUtils#encodeHeaders` and `com.uber.tchannel.codecs.CodecUtils#encodeSmallHeaders` are not NullPointerException safe memory allocation is wrapped into try/finally. 