### PR TITLE
Make ThriftRequest.Builder#build() and ThriftResponse.Builder#build() auto release ByteBuf if validation fails

### DIFF
--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedRequest.java
@@ -145,7 +145,6 @@ public abstract class EncodedRequest<T> extends Request implements TraceableRequ
 
         private Builder<T> validateHeader() {
             if (arg2 != null) {
-                headers = null;
                 return this;
             }
 
@@ -156,7 +155,6 @@ public abstract class EncodedRequest<T> extends Request implements TraceableRequ
 
         private Builder<T> validateBody() {
             if (arg3 != null) {
-                body = null;
                 return this;
             }
 

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedResponse.java
@@ -152,8 +152,6 @@ public abstract class EncodedResponse<T> extends Response {
         private @NotNull Builder<T> validateHeader() {
             if (arg2 == null) {
                 arg2 = serializer.encodeHeaders(this.headers, argScheme);
-            } else {
-                headers = null;
             }
             return this;
         }
@@ -161,8 +159,6 @@ public abstract class EncodedResponse<T> extends Response {
         private @NotNull Builder<T> validateBody() {
             if (arg3 == null) {
                 arg3 = body == null ? TChannelUtilities.emptyByteBuf : serializer.encodeBody(this.body, argScheme);
-            } else {
-                body = null;
             }
             return this;
         }
@@ -170,12 +166,12 @@ public abstract class EncodedResponse<T> extends Response {
         @Override
         public @NotNull Builder<T> validate() throws IllegalStateException {
             super.validate();
-            this.validateHeader();
-            this.validateBody();
-
             if (responseCode == null) {
                 throw new IllegalStateException("`responseCode` cannot be null.");
             }
+            //these two methods allocate native memory, put them the last
+            this.validateHeader();
+            this.validateBody();
 
             return this;
         }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
@@ -382,11 +382,10 @@ public abstract class Request implements RawMessage {
         }
 
         public void release() {
-            if (arg1 != null) {
-                arg1.release();
-                arg1 = null;
-            }
-
+            //no need to clear arg1, the places where arg1 is set are:
+            // a) Builder(java.lang.String, java.lang.String) uses Unpooled.wrappedBuffer
+            // b) Builder.Builder(java.lang.String, io.netty.buffer.ByteBuf) - we haven't allocated ByteBuf, we
+            // shouldn't clean it up
             if (arg2 != null) {
                 arg2.release();
                 arg2 = null;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
@@ -381,6 +381,23 @@ public abstract class Request implements RawMessage {
             return this;
         }
 
+        public void release() {
+            if (arg1 != null) {
+                arg1.release();
+                arg1 = null;
+            }
+
+            if (arg2 != null) {
+                arg2.release();
+                arg2 = null;
+            }
+
+            if (arg3 != null) {
+                arg3.release();
+                arg3 = null;
+            }
+        }
+
     }
 
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Response.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Response.java
@@ -288,6 +288,20 @@ public abstract class Response extends ResponseMessage implements RawMessage {
             return this;
         }
 
+        public void release() {
+            //arg1 is static and Global, no need to release
+
+            if (arg2 != null) {
+                arg2.release();
+                arg2 = null;
+            }
+
+            if (arg3 != null) {
+                arg3.release();
+                arg3 = null;
+            }
+        }
+
     }
 
 }

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
@@ -79,8 +79,6 @@ public class ThriftRequest<T> extends EncodedRequest<T> {
          *
          * Args above will be auto-released if validation fails.
          *
-         * Note: Don't call it again if fails.
-         * <br/>unless header/body are re-populated this method will fail if called after the initial failure.
          */
         public ThriftRequest<T> build() {
             ThriftRequest<T> result;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
@@ -58,14 +58,43 @@ public class ThriftRequest<T> extends EncodedRequest<T> {
             this.argScheme = ArgScheme.THRIFT;
         }
 
+        /**
+         * Validates payload and populates {@link #arg1}, {@link #arg2}, {@link #arg3}.
+         *
+         * Args <b>>need</b> to be cleared if validation fails.
+         *
+         * Use {@link #release()} to clear args above.
+         *
+         * @throws Exception
+         *     if validation fails.
+         */
         @Override
         public Builder<T> validate() {
             super.validate();
             return this;
         }
 
+        /**
+         * Validates payload, populates {@link #arg1}, {@link #arg2}, {@link #arg3} and builds {@link ThriftRequest}.
+         *
+         * Args above will be auto-released if validation fails.
+         *
+         * Note: Don't call it again if fails.
+         * <br/>unless header/body are re-populated this method will fail if called after the initial failure.
+         */
         public ThriftRequest<T> build() {
-            return new ThriftRequest<>(this.validate());
+            ThriftRequest<T> result;
+            boolean release = true;
+            try {
+                Builder<T> validated = this.validate();
+                result = new ThriftRequest<>(validated);
+                release = false;
+            } finally {
+                if (release) {
+                    this.release();
+                }
+            }
+            return result;
         }
 
         @Override

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftResponse.java
@@ -55,14 +55,43 @@ public final class ThriftResponse<T> extends EncodedResponse<T> {
             this.argScheme = ArgScheme.THRIFT;
         }
 
+        /**
+         * Validates payload and populates {@link #arg1}, {@link #arg2}, {@link #arg3}.
+         *
+         * Args <b>>need</b> to be cleared if validation fails.
+         *
+         * Use {@link #release()} to clear args above.
+         *
+         * @throws Exception
+         *     if validation fails.
+         */
         @Override
         public @NotNull Builder<T> validate() {
             super.validate();
             return this;
         }
 
+        /**
+         * Validates payload, populates {@link #arg1}, {@link #arg2}, {@link #arg3} and builds {@link ThriftResponse}.
+         *
+         * Args above will be auto-released if validation fails.
+         *
+         * Note: Don't call it again if fails.
+         * <br/>unless header/body are re-populated this method will fail if called after the initial failure.
+         */
         public @NotNull ThriftResponse<T> build() {
-            return new ThriftResponse<>(this.validate());
+            ThriftResponse<T> result;
+            boolean release = true;
+            try {
+                ThriftResponse.Builder<T> validated = this.validate();
+                result = new ThriftResponse<>(validated);
+                release = false;
+            } finally {
+                if (release) {
+                    this.release();
+                }
+            }
+            return result;
         }
 
         @Override

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftResponse.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftResponse.java
@@ -76,8 +76,6 @@ public final class ThriftResponse<T> extends EncodedResponse<T> {
          *
          * Args above will be auto-released if validation fails.
          *
-         * Note: Don't call it again if fails.
-         * <br/>unless header/body are re-populated this method will fail if called after the initial failure.
          */
         public @NotNull ThriftResponse<T> build() {
             ThriftResponse<T> result;

--- a/tchannel-core/src/test/java/com/uber/tchannel/messages/RequestFormatTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/messages/RequestFormatTest.java
@@ -125,10 +125,10 @@ public class RequestFormatTest {
     }
 
     /**
-     * Body serialization should never fail
+     * Body serialization should never fail if serializable
      */
     @Test
-    public void testCantSerializeBody() throws Exception {
+    public void testCantSerializeBodySoftError() throws Exception {
         ThriftRequest<ExampleWithRequiredField> request = new ThriftRequest.Builder<ExampleWithRequiredField>("keyvalue-service", "KeyValue::setValue")
             .setBody(new ExampleWithRequiredField())
             .build();
@@ -146,5 +146,52 @@ public class RequestFormatTest {
         assertNull(request.getArg1());
         assertNull(request.getArg2());
         assertNull(request.getArg3());
+    }
+
+    @Test
+    public void testCantSerializeBodyHardError() throws Exception {
+        ThriftRequest.Builder<NonSerializable> builder = new ThriftRequest.Builder<NonSerializable>(
+            "keyvalue-service",
+            "KeyValue::setValue"
+        )
+            .setBody(new NonSerializable());
+        try {
+            builder.build();
+            fail();
+        } catch (Exception e) {
+            //expected
+        }
+        assertNull(builder.getArg1());
+        assertNull(builder.arg2);
+        assertNull(builder.arg3);
+
+        try {
+            builder.build();
+            fail();
+        } catch (Exception e) {
+            //expected
+        }
+        assertNull(builder.getArg1());
+        assertNull(builder.arg2);
+        assertNull(builder.arg3);
+    }
+
+    @Test
+    public void testReuseBuilder() throws Exception {
+        ThriftRequest.Builder<Example> builder = new ThriftRequest.Builder<Example>(
+            "keyvalue-service",
+            "KeyValue::setValue"
+        )
+            .setBody(new Example());
+        ThriftRequest<Example> req1 = builder.build();
+        ThriftRequest<Example> req2 = builder.build();
+
+        assertTrue(req1 != req2);
+        assertEquals(req1.getArg1(), req2.getArg1());
+        assertEquals(req1.getArg2(), req2.getArg2());
+        assertEquals(req1.getArg3(), req2.getArg3());
+    }
+
+    public static class NonSerializable {
     }
 }

--- a/tchannel-core/src/test/java/com/uber/tchannel/messages/ResponseTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/messages/ResponseTest.java
@@ -1,0 +1,58 @@
+package com.uber.tchannel.messages;
+
+import com.uber.tchannel.messages.generated.Example;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ResponseTest {
+
+    @Test
+    public void testCantSerializeBodyHardError() throws Exception {
+        ThriftRequest<Example> request = new ThriftRequest.Builder<Example>("keyvalue-service", "KeyValue::setValue")
+            .build();
+        ThriftResponse.Builder<NonSerializable> builder = new ThriftResponse.Builder<NonSerializable>(
+            request)
+            .setBody(new NonSerializable());
+        try {
+            builder.build();
+            fail();
+        } catch (Exception e) {
+            //expected
+        }
+        assertNull(builder.arg2);
+        assertNull(builder.arg3);
+
+        try {
+            builder.build();
+            fail();
+        } catch (Exception e) {
+            //expected
+        }
+        assertNull(builder.arg2);
+        assertNull(builder.arg3);
+    }
+
+    @Test
+    public void testReuseBuilder() throws Exception {
+        ThriftRequest<Example> request = new ThriftRequest.Builder<Example>("keyvalue-service", "KeyValue::setValue")
+            .build();
+
+        ThriftResponse.Builder<Example> builder = new ThriftResponse.Builder<Example>(request)
+            .setBody(new Example());
+        ThriftResponse<Example> resp1 = builder.build();
+        ThriftResponse<Example> resp2 = builder.build();
+
+        assertTrue(resp1 != resp2);
+        assertEquals(resp1.getArg1(), resp2.getArg1());
+        assertEquals(resp1.getArg2(), resp2.getArg2());
+        assertEquals(resp1.getArg3(), resp2.getArg3());
+    }
+
+    public static class NonSerializable {
+
+    }
+}


### PR DESCRIPTION
Both `ThriftRequest.Builder#validate()` and `ThriftResponse.Builder#validate()` are stateful, i.e. they modify state of the Builder object.  

`ThriftRequest.Builder#validate()`:

```
        @Override
        public Builder<T> validate() {
            super.validate();
            this.validateHeader();
            this.validateBody();
            return this;
        }

        private Builder<T> validateHeader() {
            if (arg2 != null) {
                headers = null;
                return this;
            }

            arg2 = serializer.encodeHeaders(this.headers, argScheme);

            return this;
        }

        private Builder<T> validateBody() {
            if (arg3 != null) {
                body = null;
                return this;
            }

            if (body == null) {
                arg3 = TChannelUtilities.emptyByteBuf;
            } else {
                arg3 = serializer.encodeBody(this.body, argScheme);
            }

            return this;
        }
```
Hence if body validation fails we end up with native memory leak in ByteBuf: ByteBuf is already allocated for the headers.

**Builders** can be re-used once the problem with headers or body fixed. Added tests for it.