### PR TITLE
Added option to force Heap Buffer for headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.19.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>1.4</version>

--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -134,7 +134,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallRequestFrameContinueCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallRequestFrameContinueCodecTest.java
@@ -24,17 +24,12 @@ package com.uber.tchannel.codecs;
 
 import com.uber.tchannel.Fixtures;
 import com.uber.tchannel.ResultCaptor;
-import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.frames.CallRequestContinueFrame;
-import com.uber.tchannel.frames.CallRequestFrame;
-import com.uber.tchannel.frames.InitFrame;
-import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 
 import org.junit.Test;
 

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallResponseFrameCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallResponseFrameCodecTest.java
@@ -26,7 +26,6 @@ import com.uber.tchannel.Fixtures;
 import com.uber.tchannel.ResultCaptor;
 import com.uber.tchannel.api.ResponseCode;
 import com.uber.tchannel.checksum.ChecksumType;
-import com.uber.tchannel.frames.CallRequestContinueFrame;
 import com.uber.tchannel.frames.CallResponseFrame;
 import com.uber.tchannel.frames.InitFrame;
 import com.uber.tchannel.tracing.Trace;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallResponseFrameContinueCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CallResponseFrameContinueCodecTest.java
@@ -24,11 +24,7 @@ package com.uber.tchannel.codecs;
 
 import com.uber.tchannel.Fixtures;
 import com.uber.tchannel.ResultCaptor;
-import com.uber.tchannel.api.ResponseCode;
-import com.uber.tchannel.checksum.ChecksumType;
 import com.uber.tchannel.frames.CallResponseContinueFrame;
-import com.uber.tchannel.frames.CallResponseFrame;
-import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CancelCodecTest.java
@@ -26,9 +26,7 @@ import com.uber.tchannel.frames.CancelFrame;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
 import org.junit.Test;
-import org.mockito.internal.matchers.Null;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/ClaimFrameCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/ClaimFrameCodecTest.java
@@ -22,7 +22,6 @@
 package com.uber.tchannel.codecs;
 
 import com.uber.tchannel.ResultCaptor;
-import com.uber.tchannel.frames.CancelFrame;
 import com.uber.tchannel.frames.ClaimFrame;
 import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/CodecUtilsTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/CodecUtilsTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/InitRequestFrameCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/InitRequestFrameCodecTest.java
@@ -28,11 +28,8 @@ import com.uber.tchannel.frames.InitRequestFrame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.HashMap;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/tchannel-core/src/test/java/com/uber/tchannel/codecs/TFrameCodecTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/codecs/TFrameCodecTest.java
@@ -25,7 +25,6 @@ import com.uber.tchannel.frames.FrameType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 


### PR DESCRIPTION
### **Rationale.**

- A good number of native memory leaks are coming from the library user code, i.e. 

```
            request = new ThriftRequest.Builder<KeyValue.setValue_args>("keyvalue-service", "KeyValue::setValue")
                    .setTimeout(1000)
                    .setBody(setValue)
                    .build();
            // do something else that results in the error
            subChannel.send(request);
```
Meaning if there is an error between ThriftRequest / ThriftResponse constructed and it handed over to tchannel, then Memory will leak. Instead of fixing all of usages, we can take small performance hit (see next bullet).
- Body is majority of the Tchannel payload and `com.uber.tchannel.messages.ThriftSerializer#encodeBody` uses heap ByteBuf, using Heap ByteBuf for the headers won't make big difference. 