### PR TITLE
Don't allocate new ByteBuf for empty headers

### DIFF
--- a/tchannel-core/src/test/java/com/uber/tchannel/messages/ThriftSerializerTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/messages/ThriftSerializerTest.java
@@ -89,7 +89,9 @@ public class ThriftSerializerTest {
 
     @Test
     public void testEncodeDecodeEmptyHeaders() {
-        Map<String, String> emptyHeaders = new HashMap<>();
+        Map<String, String> emptyHeaders = new HashMap<String, String>(){{
+            put("key", "value");
+        }};
         ByteBuf binaryHeaders = serializer.encodeHeaders(emptyHeaders);
         assertTrue(binaryHeaders.isDirect());
         assertFalse(binaryHeaders.hasArray());
@@ -112,6 +114,14 @@ public class ThriftSerializerTest {
     }
 
     @Test
+    public void testEmptyHeadersBackedByHeapConstantByteBuf() {
+        Map<String, String> emptyHeaders = new HashMap<>();
+        ByteBuf binaryHeaders = serializer.encodeHeaders(emptyHeaders);
+        assertTrue(binaryHeaders.hasArray());
+        assertFalse(binaryHeaders.isDirect());
+    }
+
+    @Test
     public void testDirectBufferPreferred() {
         assertEquals(PlatformDependent.directBufferPreferred(), ThriftSerializer.directBufferPreferred());
         assertTrue(ThriftSerializer.directBufferPreferred());
@@ -123,7 +133,11 @@ public class ThriftSerializerTest {
         ThriftSerializer.init();
         assertFalse(ThriftSerializer.directBufferPreferred());
 
-        ByteBuf binaryHeaders = serializer.encodeHeaders(new HashMap<String, String>());
+        ByteBuf binaryHeaders = serializer.encodeHeaders(new HashMap<String, String>() {
+            {
+                put("key", "value");
+            }
+        });
         assertTrue(binaryHeaders.hasArray());
         assertFalse(binaryHeaders.isDirect());
 


### PR DESCRIPTION
80% of our code don't send any headers, hence allocating bytebuf is both wastefull and errorprone.

Make it constant.

The constant ByteByf itself is:

```
ByteBuf b = allocate();
buffer.writeShort(0); // size of the headers.

```