### PR TITLE
Inject/extract trace information into/from request

### DIFF
--- a/tchannel-core/pom.xml
+++ b/tchannel-core/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
         </dependency>
@@ -103,10 +107,6 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -117,11 +117,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tchannel-core/src/main/java/com/uber/tchannel/codecs/MessageCodec.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/codecs/MessageCodec.java
@@ -141,6 +141,7 @@ public final class MessageCodec {
             scheme,
             first.getId(),
             first.getTTL(),
+            first.getTracing(),
             first.getService(),
             first.getHeaders(),
             args.get(0),

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -89,7 +89,7 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
                     request.getId(),
                     (byte)0,
                     request.getTTL(),
-                    new Trace(0, 0, 0, (byte) 0x00),
+                    request.getTrace(),
                     request.getService(),
                     request.getTransportHeaders(),
                     ChecksumType.NoChecksum,

--- a/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/handlers/MessageFragmenter.java
@@ -45,6 +45,8 @@ import java.util.List;
 
 public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
 
+    private static final Trace DUMMY_TRACE = new Trace(0, 0, 0, (byte) 0x00);
+
     @Override
     protected void encode(ChannelHandlerContext ctx, RawMessage msg, List<Object> out) throws Exception {
         writeFrames(ctx, msg, out);
@@ -89,7 +91,8 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
                     request.getId(),
                     (byte)0,
                     request.getTTL(),
-                    request.getTrace(),
+                    // trace is required to be nonNull down the stack when frame is encoded
+                    request.getTrace() == null ? DUMMY_TRACE : request.getTrace(),
                     request.getService(),
                     request.getTransportHeaders(),
                     ChecksumType.NoChecksum,
@@ -112,7 +115,7 @@ public class MessageFragmenter extends MessageToMessageEncoder<RawMessage> {
                     response.getId(),
                     (byte)0,
                     response.getResponseCode(),
-                    new Trace(0, 0, 0, (byte) 0x00),
+                    DUMMY_TRACE,
                     response.getTransportHeaders(),
                     ChecksumType.NoChecksum,
                     0,

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/EncodedRequest.java
@@ -24,6 +24,7 @@ package com.uber.tchannel.messages;
 
 import com.google.common.collect.ImmutableMap;
 import com.uber.tchannel.headers.ArgScheme;
+import com.uber.tchannel.tracing.Trace;
 import com.uber.tchannel.tracing.TraceableRequest;
 import com.uber.tchannel.utils.TChannelUtilities;
 import io.netty.buffer.ByteBuf;
@@ -47,10 +48,10 @@ public abstract class EncodedRequest<T> extends Request implements TraceableRequ
         this.headers = builder.headers;
     }
 
-    protected EncodedRequest(long id, long ttl,
+    protected EncodedRequest(long id, long ttl, Trace trace,
                          String service, Map<String, String> transportHeaders,
                          ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
-        super(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+        super(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
     }
 
     @Override

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/JsonRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/JsonRequest.java
@@ -24,6 +24,7 @@ package com.uber.tchannel.messages;
 
 import com.uber.tchannel.headers.ArgScheme;
 import com.uber.tchannel.headers.TransportHeaders;
+import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Map;
@@ -35,10 +36,10 @@ public class JsonRequest<T> extends EncodedRequest<T> {
         super(builder);
     }
 
-    protected JsonRequest(long id, long ttl,
+    protected JsonRequest(long id, long ttl, Trace trace,
                              String service, Map<String, String> transportHeaders,
                              ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
-        super(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+        super(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
     }
 
     /**

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/RawRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/RawRequest.java
@@ -24,6 +24,7 @@ package com.uber.tchannel.messages;
 
 import com.uber.tchannel.headers.ArgScheme;
 import com.uber.tchannel.headers.TransportHeaders;
+import com.uber.tchannel.tracing.Trace;
 import com.uber.tchannel.utils.TChannelUtilities;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -43,10 +44,10 @@ public final class RawRequest extends Request {
         this.header = builder.header;
     }
 
-    protected RawRequest(long id, long ttl,
+    protected RawRequest(long id, long ttl, Trace trace,
                       String service, Map<String, String> transportHeaders,
                       ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
-        super(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+        super(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
     }
 
     public String getHeader() {

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public abstract class Request implements RawMessage {
-    private static final Trace DUMMY_TRACE = new Trace(0, 0, 0, (byte) 0x00);
 
     protected final FrameType type = FrameType.CallRequest;
 
@@ -231,7 +230,7 @@ public abstract class Request implements RawMessage {
     }
 
     public Trace getTrace() {
-        return trace == null ? DUMMY_TRACE : trace;
+        return trace;
     }
 
     public long getTTL() {

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/Request.java
@@ -27,6 +27,7 @@ import com.uber.tchannel.frames.FrameType;
 import com.uber.tchannel.headers.ArgScheme;
 import com.uber.tchannel.headers.RetryFlag;
 import com.uber.tchannel.headers.TransportHeaders;
+import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
@@ -39,8 +40,11 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public abstract class Request implements RawMessage {
+    private static final Trace DUMMY_TRACE = new Trace(0, 0, 0, (byte) 0x00);
 
     protected final FrameType type = FrameType.CallRequest;
+
+    protected Trace trace = null;
 
     protected long id = -1;
     protected String service = null;
@@ -65,11 +69,12 @@ public abstract class Request implements RawMessage {
         this.retryLimit = builder.retryLimit;
     }
 
-    protected Request(long id, long ttl,
+    protected Request(long id, long ttl, Trace trace,
                       String service, Map<String, String> transportHeaders,
                       ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
         this.id = id;
         this.ttl = ttl;
+        this.trace = trace;
         this.service = service;
         this.arg1 = arg1;
         this.arg2 = arg2;
@@ -221,6 +226,14 @@ public abstract class Request implements RawMessage {
         this.id = id;
     }
 
+    public void setTrace(Trace trace) {
+        this.trace = trace;
+    }
+
+    public Trace getTrace() {
+        return trace == null ? DUMMY_TRACE : trace;
+    }
+
     public long getTTL() {
         return ttl;
     }
@@ -280,7 +293,7 @@ public abstract class Request implements RawMessage {
         setTransportHeader(TransportHeaders.RETRY_FLAGS_KEY, flags);
     }
 
-    public static @Nullable Request build(long id, long ttl,
+    public static @Nullable Request build(long id, long ttl, Trace trace,
                                 String service, Map<String, String> transportHeaders,
                                 ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
         ArgScheme argScheme = ArgScheme.toScheme(transportHeaders.get(TransportHeaders.ARG_SCHEME_KEY));
@@ -288,22 +301,22 @@ public abstract class Request implements RawMessage {
             return null;
         }
 
-        return Request.build(argScheme, id, ttl, service, transportHeaders, arg1, arg2, arg3);
+        return Request.build(argScheme, id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
     }
 
-    public static @Nullable Request build(ArgScheme argScheme, long id, long ttl,
+    public static @Nullable Request build(ArgScheme argScheme, long id, long ttl, Trace trace,
                                 String service, Map<String, String> transportHeaders,
                                 ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
         Request req;
         switch (argScheme) {
             case RAW:
-                req = new RawRequest(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+                req = new RawRequest(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
                 break;
             case JSON:
-                req = new JsonRequest<>(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+                req = new JsonRequest<>(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
                 break;
             case THRIFT:
-                req = new ThriftRequest<>(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+                req = new ThriftRequest<>(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
                 break;
             default:
                 req = null;

--- a/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
+++ b/tchannel-core/src/main/java/com/uber/tchannel/messages/ThriftRequest.java
@@ -24,6 +24,7 @@ package com.uber.tchannel.messages;
 
 import com.uber.tchannel.headers.ArgScheme;
 import com.uber.tchannel.headers.TransportHeaders;
+import com.uber.tchannel.tracing.Trace;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Map;
@@ -35,10 +36,10 @@ public class ThriftRequest<T> extends EncodedRequest<T> {
         super(builder);
     }
 
-    protected ThriftRequest(long id, long ttl,
+    protected ThriftRequest(long id, long ttl, Trace trace,
                           String service, Map<String, String> transportHeaders,
                           ByteBuf arg1, ByteBuf arg2, ByteBuf arg3) {
-        super(id, ttl, service, transportHeaders, arg1, arg2, arg3);
+        super(id, ttl, trace, service, transportHeaders, arg1, arg2, arg3);
     }
 
     /**

--- a/tchannel-core/src/test/java/com/uber/tchannel/tracing/InboundRequestTraceTest.java
+++ b/tchannel-core/src/test/java/com/uber/tchannel/tracing/InboundRequestTraceTest.java
@@ -1,0 +1,60 @@
+package com.uber.tchannel.tracing;
+
+import com.uber.tchannel.messages.JsonRequest;
+import com.uber.tchannel.messages.Request;
+import io.jaegertracing.internal.JaegerSpanContext;
+import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.reporters.InMemoryReporter;
+import io.jaegertracing.internal.samplers.ConstSampler;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class InboundRequestTraceTest {
+    private Tracer tracer = null;
+    private Request request = null;
+
+    @Before
+    public void setUp() {
+        tracer = new JaegerTracer.Builder("tchannel-name")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
+            .build();
+
+        request = new JsonRequest
+            .Builder<String>("tchannel-name", "endpoint")
+            .setTimeout(1000, TimeUnit.MILLISECONDS)
+            .setRetryLimit(0)
+            .setBody("foo")
+            .build();
+    }
+
+    @Test
+    public void testInboundRequestWithNullTrace() {
+        assertNull(request.getTrace());
+        try {
+            Span span =Tracing.startInboundSpan(request,tracer, new TracingContext.Default());
+            assertNotNull(span);
+        } catch (Exception e) {
+            fail("Should not have thrown exception");
+        }
+    }
+
+    @Test
+    public void testInboundRequestWithNonNullTrace() {
+        Trace trace = new Trace(42, 0, 42, (byte) 1);
+        request.setTrace(trace);
+
+        Span span = Tracing.startInboundSpan(request,tracer, new TracingContext.Default());
+        JaegerSpanContext spanContext = (JaegerSpanContext) span.context();
+        assertEquals(trace.traceId, spanContext.getTraceIdLow());
+        assertEquals(trace.spanId, spanContext.getParentId());
+        assertEquals(trace.traceFlags, spanContext.getFlags());
+        assertNotEquals(trace.spanId, spanContext.getSpanId());
+    }
+}


### PR DESCRIPTION
This PR does the following:
- Inject tracing info into outbound request (call request frame) besides header;
- Extract tracing info from inbound request when tracing info isn't present in headers.

Rationale:
-  TChannel has built-in support for propagating [tracing info](https://github.com/uber/tchannel/blob/master/docs/protocol.md#tracing) with reserved bytes in [call req frame](https://github.com/uber/tchannel/blob/master/docs/protocol.md#call-req-type-0x03).
- TChannel-go [creates](https://github.com/uber/tchannel-go/blob/dev/inbound.go#L86) spans with tracing info in call req frame (not from headers), so if a tchannel-java client calls tchannel-go server with trace info carried in headers, the server span would be missing since request form tchannel-java client does not contain tracing info. [Here](https://code.uberinternal.com/T5310765) is an Uber internal reference.